### PR TITLE
Improve UX: Move asset registration to modal with New Asset button

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import AssetRegistrationForm from './components/AssetRegistrationForm';
 import AssetList from './components/AssetList';
 import CompanyManagement from './components/CompanyManagement';
 import AuditReporting from './components/AuditReporting';
@@ -41,10 +40,7 @@ function App() {
       </div>
 
       {activeTab === 'assets' && (
-        <div className="main-content">
-          <AssetRegistrationForm onAssetRegistered={handleAssetRegistered} />
-          <AssetList refresh={refreshKey} />
-        </div>
+        <AssetList refresh={refreshKey} onAssetRegistered={handleAssetRegistered} />
       )}
 
       {activeTab === 'companies' && <CompanyManagement />}

--- a/frontend/src/components/AssetList.jsx
+++ b/frontend/src/components/AssetList.jsx
@@ -1,13 +1,15 @@
 import { useState, useEffect } from 'react';
 import StatusUpdateModal from './StatusUpdateModal';
+import AssetRegistrationForm from './AssetRegistrationForm';
 
-const AssetList = ({ refresh }) => {
+const AssetList = ({ refresh, onAssetRegistered }) => {
   const [assets, setAssets] = useState([]);
   const [filteredAssets, setFilteredAssets] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedAsset, setSelectedAsset] = useState(null);
-  const [showModal, setShowModal] = useState(false);
+  const [showStatusModal, setShowStatusModal] = useState(false);
+  const [showRegistrationModal, setShowRegistrationModal] = useState(false);
 
   const [filters, setFilters] = useState({
     employee: '',
@@ -93,17 +95,33 @@ const AssetList = ({ refresh }) => {
 
   const handleStatusUpdate = (asset) => {
     setSelectedAsset(asset);
-    setShowModal(true);
+    setShowStatusModal(true);
   };
 
-  const handleModalClose = () => {
-    setShowModal(false);
+  const handleStatusModalClose = () => {
+    setShowStatusModal(false);
     setSelectedAsset(null);
   };
 
   const handleStatusUpdated = () => {
     fetchAssets();
-    handleModalClose();
+    handleStatusModalClose();
+  };
+
+  const handleNewAssetClick = () => {
+    setShowRegistrationModal(true);
+  };
+
+  const handleRegistrationModalClose = () => {
+    setShowRegistrationModal(false);
+  };
+
+  const handleAssetRegistered = (asset) => {
+    setShowRegistrationModal(false);
+    fetchAssets();
+    if (onAssetRegistered) {
+      onAssetRegistered(asset);
+    }
   };
 
   const formatDate = (dateString) => {
@@ -138,7 +156,16 @@ const AssetList = ({ refresh }) => {
 
   return (
     <div className="card">
-      <h2>Asset Inventory ({filteredAssets.length} assets)</h2>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+        <h2>Asset Inventory ({filteredAssets.length} assets)</h2>
+        <button
+          onClick={handleNewAssetClick}
+          className="btn btn-primary"
+          style={{ width: 'auto', padding: '10px 20px' }}
+        >
+          + New Asset
+        </button>
+      </div>
 
       <div className="search-bar">
         <input
@@ -240,12 +267,27 @@ const AssetList = ({ refresh }) => {
         </div>
       )}
 
-      {showModal && selectedAsset && (
+      {showStatusModal && selectedAsset && (
         <StatusUpdateModal
           asset={selectedAsset}
-          onClose={handleModalClose}
+          onClose={handleStatusModalClose}
           onUpdate={handleStatusUpdated}
         />
+      )}
+
+      {showRegistrationModal && (
+        <div className="modal-overlay" onClick={handleRegistrationModalClose}>
+          <div className="modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '600px' }}>
+            <AssetRegistrationForm onAssetRegistered={handleAssetRegistered} />
+            <button
+              onClick={handleRegistrationModalClose}
+              className="btn btn-secondary"
+              style={{ marginTop: '20px' }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Changed the asset management layout to show registration form in a modal instead of always displaying it on the left side. This provides a cleaner, more focused interface.

Changes:
- AssetList component (frontend/src/components/AssetList.jsx):
  * Added "New Asset" button next to Asset Inventory title
  * Integrated AssetRegistrationForm as a modal
  * Added showRegistrationModal state for modal visibility
  * Modal appears when clicking "New Asset" button
  * Modal closes on cancel or successful registration
  * Refreshes asset list after registration
  * Renamed showModal to showStatusModal for clarity

- App component (frontend/src/App.jsx):
  * Removed always-visible AssetRegistrationForm from layout
  * Simplified layout - no longer uses grid for assets tab
  * AssetList now full-width with integrated registration
  * Removed unused AssetRegistrationForm import

Benefits:
- Cleaner interface with more space for asset table
- Registration form appears only when needed
- Consistent modal pattern with status updates
- Better use of screen real estate
- More intuitive workflow for users