### PR TITLE
Restrict company management to admins and add first admin setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,9 @@ DATA_DIR=/app/data
 
 # JWT Authentication
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_EXPIRES_IN=7d
+
+# Admin Email - Users with this email will automatically be granted admin role
+# The first user to register will automatically become admin regardless of this setting
+# Uncomment and set your admin email below:
+# ADMIN_EMAIL=admin@yourdomain.com

--- a/backend/database.js
+++ b/backend/database.js
@@ -85,7 +85,7 @@ const initDb = () => {
       email TEXT NOT NULL UNIQUE,
       password_hash TEXT NOT NULL,
       name TEXT NOT NULL,
-      role TEXT NOT NULL DEFAULT 'user',
+      role TEXT NOT NULL DEFAULT 'employee',
       created_at TEXT NOT NULL,
       last_login TEXT,
       first_name TEXT,
@@ -428,7 +428,7 @@ export const userDb = {
       user.email,
       user.password_hash,
       fullName,
-      user.role || 'user',
+      user.role || 'employee',
       now,
       user.first_name || null,
       user.last_name || null

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,12 +53,14 @@ function App() {
         >
           Asset Management
         </button>
-        <button
-          className={`tab ${activeTab === 'companies' ? 'active' : ''}`}
-          onClick={() => setActiveTab('companies')}
-        >
-          Company Management
-        </button>
+        {user?.role === 'admin' && (
+          <button
+            className={`tab ${activeTab === 'companies' ? 'active' : ''}`}
+            onClick={() => setActiveTab('companies')}
+          >
+            Company Management
+          </button>
+        )}
         <button
           className={`tab ${activeTab === 'audit' ? 'active' : ''}`}
           onClick={() => setActiveTab('audit')}
@@ -86,7 +88,7 @@ function App() {
         <AssetList refresh={refreshKey} onAssetRegistered={handleAssetRegistered} />
       )}
 
-      {activeTab === 'companies' && <CompanyManagement />}
+      {activeTab === 'companies' && user?.role === 'admin' && <CompanyManagement />}
 
       {activeTab === 'audit' && <AuditReporting />}
 

--- a/frontend/src/components/AssetRegistrationForm.jsx
+++ b/frontend/src/components/AssetRegistrationForm.jsx
@@ -25,7 +25,7 @@ const AssetRegistrationForm = ({ onAssetRegistered }) => {
 
   const fetchCompanies = async () => {
     try {
-      const response = await fetch('/api/companies', {
+      const response = await fetch('/api/companies/names', {
         headers: {
           ...getAuthHeaders()
         }


### PR DESCRIPTION
This commit implements admin-only company management and provides two methods for setting up the first admin user.

Backend changes:
- Restricted all company management endpoints to admin role only:
  * GET /api/companies (full details)
  * POST /api/companies
  * PUT /api/companies/:id
  * DELETE /api/companies/:id
- Added GET /api/companies/names endpoint for all authenticated users
  * Returns only id and name for dropdown use in asset registration
  * Allows non-admin users to register assets with company selection
- Implemented automatic admin user creation:
  * First registered user automatically becomes admin
  * Users with email matching ADMIN_EMAIL env var become admin
  * Default role changed from 'user' to 'employee' for all other users
- Added console logging when admin users are created
- Updated database default role to 'employee'

Frontend changes:
- Hide Company Management tab for non-admin users
- Only show Company Management when user role is 'admin'
- Updated AssetRegistrationForm to use /api/companies/names endpoint
- Maintains company dropdown functionality for all users

Configuration:
- Updated .env.example with ADMIN_EMAIL documentation
- Added JWT_EXPIRES_IN configuration example
- Clear instructions on admin user setup methods

Admin setup methods:
1. First User Method: The very first user to register becomes admin automatically
2. ADMIN_EMAIL Method: Set ADMIN_EMAIL environment variable to grant specific users admin role upon registration

Benefits:
- Simplified initial setup - first user is always admin
- Flexible admin assignment via environment variable
- Company management restricted to trusted admins
- All users can still register assets with company selection
- Clear separation of admin and non-admin capabilities