### PR TITLE
Add password change functionality to user profile

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -480,6 +480,12 @@ export const userDb = {
     return stmt.run(fullName, profile.first_name, profile.last_name, id);
   },
 
+  // Update user password
+  updatePassword: (id, passwordHash) => {
+    const stmt = db.prepare('UPDATE users SET password_hash = ? WHERE id = ?');
+    return stmt.run(passwordHash, id);
+  },
+
   // Delete user
   delete: (id) => {
     const stmt = db.prepare('DELETE FROM users WHERE id = ?');

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -7,9 +7,17 @@ const Profile = () => {
     first_name: '',
     last_name: ''
   });
+  const [passwordData, setPasswordData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: ''
+  });
   const [loading, setLoading] = useState(false);
+  const [passwordLoading, setPasswordLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [passwordError, setPasswordError] = useState(null);
   const [success, setSuccess] = useState(false);
+  const [passwordSuccess, setPasswordSuccess] = useState(false);
 
   useEffect(() => {
     // Initialize form with user data
@@ -24,6 +32,13 @@ const Profile = () => {
   const handleChange = (e) => {
     setFormData({
       ...formData,
+      [e.target.name]: e.target.value
+    });
+  };
+
+  const handlePasswordChange = (e) => {
+    setPasswordData({
+      ...passwordData,
       [e.target.name]: e.target.value
     });
   };
@@ -63,74 +78,191 @@ const Profile = () => {
     }
   };
 
-  return (
-    <div className="card" style={{ maxWidth: '600px', margin: '0 auto' }}>
-      <h2>Profile Management</h2>
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    setPasswordLoading(true);
+    setPasswordError(null);
+    setPasswordSuccess(false);
 
-      <div style={{ marginBottom: '30px', padding: '15px', background: '#f7fafc', borderRadius: '6px' }}>
-        <p><strong>Email:</strong> {user?.email}</p>
-        <p>
-          <strong>Role:</strong>{' '}
-          <span
-            style={{
-              textTransform: 'capitalize',
-              padding: '4px 12px',
-              borderRadius: '4px',
-              background: user?.role === 'admin' ? '#667eea' : user?.role === 'manager' ? '#48bb78' : '#4299e1',
-              color: 'white',
-              fontWeight: 'bold',
-              fontSize: '0.9rem'
-            }}
-          >
-            {user?.role}
-          </span>
-        </p>
-        <p><strong>Current Name:</strong> {user?.name || 'Not set'}</p>
+    // Client-side validation
+    if (passwordData.newPassword !== passwordData.confirmPassword) {
+      setPasswordError('New password and confirmation do not match');
+      setPasswordLoading(false);
+      return;
+    }
+
+    if (passwordData.newPassword.length < 6) {
+      setPasswordError('New password must be at least 6 characters long');
+      setPasswordLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/auth/change-password', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders()
+        },
+        body: JSON.stringify(passwordData),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to change password');
+      }
+
+      setPasswordSuccess(true);
+
+      // Clear password form
+      setPasswordData({
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: ''
+      });
+
+      setTimeout(() => setPasswordSuccess(false), 5000);
+    } catch (err) {
+      setPasswordError(err.message);
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+      <div className="card" style={{ marginBottom: '30px' }}>
+        <h2>Profile Information</h2>
+
+        <div style={{ marginBottom: '30px', padding: '15px', background: '#f7fafc', borderRadius: '6px' }}>
+          <p><strong>Email:</strong> {user?.email}</p>
+          <p>
+            <strong>Role:</strong>{' '}
+            <span
+              style={{
+                textTransform: 'capitalize',
+                padding: '4px 12px',
+                borderRadius: '4px',
+                background: user?.role === 'admin' ? '#2b75a7' : user?.role === 'manager' ? '#184a7b' : '#172b51',
+                color: 'white',
+                fontWeight: 'bold',
+                fontSize: '0.9rem'
+              }}
+            >
+              {user?.role}
+            </span>
+          </p>
+          <p><strong>Current Name:</strong> {user?.name || 'Not set'}</p>
+        </div>
+
+        {success && (
+          <div className="alert alert-success">
+            Profile updated successfully!
+          </div>
+        )}
+
+        {error && (
+          <div className="alert alert-error">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="first_name">First Name *</label>
+            <input
+              type="text"
+              id="first_name"
+              name="first_name"
+              value={formData.first_name}
+              onChange={handleChange}
+              required
+              placeholder="John"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="last_name">Last Name *</label>
+            <input
+              type="text"
+              id="last_name"
+              name="last_name"
+              value={formData.last_name}
+              onChange={handleChange}
+              required
+              placeholder="Doe"
+            />
+          </div>
+
+          <button type="submit" className="btn btn-primary" disabled={loading}>
+            {loading ? 'Updating...' : 'Update Profile'}
+          </button>
+        </form>
       </div>
 
-      {success && (
-        <div className="alert alert-success">
-          Profile updated successfully!
-        </div>
-      )}
+      <div className="card">
+        <h2>Change Password</h2>
 
-      {error && (
-        <div className="alert alert-error">
-          {error}
-        </div>
-      )}
+        {passwordSuccess && (
+          <div className="alert alert-success">
+            Password changed successfully!
+          </div>
+        )}
 
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="first_name">First Name *</label>
-          <input
-            type="text"
-            id="first_name"
-            name="first_name"
-            value={formData.first_name}
-            onChange={handleChange}
-            required
-            placeholder="John"
-          />
-        </div>
+        {passwordError && (
+          <div className="alert alert-error">
+            {passwordError}
+          </div>
+        )}
 
-        <div className="form-group">
-          <label htmlFor="last_name">Last Name *</label>
-          <input
-            type="text"
-            id="last_name"
-            name="last_name"
-            value={formData.last_name}
-            onChange={handleChange}
-            required
-            placeholder="Doe"
-          />
-        </div>
+        <form onSubmit={handlePasswordSubmit}>
+          <div className="form-group">
+            <label htmlFor="currentPassword">Current Password *</label>
+            <input
+              type="password"
+              id="currentPassword"
+              name="currentPassword"
+              value={passwordData.currentPassword}
+              onChange={handlePasswordChange}
+              required
+              placeholder="Enter current password"
+            />
+          </div>
 
-        <button type="submit" className="btn btn-primary" disabled={loading}>
-          {loading ? 'Updating...' : 'Update Profile'}
-        </button>
-      </form>
+          <div className="form-group">
+            <label htmlFor="newPassword">New Password *</label>
+            <input
+              type="password"
+              id="newPassword"
+              name="newPassword"
+              value={passwordData.newPassword}
+              onChange={handlePasswordChange}
+              required
+              placeholder="Enter new password (min 6 characters)"
+              minLength={6}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="confirmPassword">Confirm New Password *</label>
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              value={passwordData.confirmPassword}
+              onChange={handlePasswordChange}
+              required
+              placeholder="Confirm new password"
+              minLength={6}
+            />
+          </div>
+
+          <button type="submit" className="btn btn-primary" disabled={passwordLoading}>
+            {passwordLoading ? 'Changing Password...' : 'Change Password'}
+          </button>
+        </form>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Users can now change their password from the Profile page with proper security validation.

Backend Changes:
- Add PUT /api/auth/change-password endpoint (server.js)
  * Requires authentication
  * Validates current password before allowing change
  * Enforces minimum 6 character password requirement
  * Verifies new password matches confirmation
  * Hashes new password with bcrypt
  * Logs password change to audit trail
- Add updatePassword() method to userDb (database.js)
  * Updates password_hash in database

Frontend Changes:
- Add "Change Password" section to Profile page (Profile.jsx)
  * Separate card with dedicated password change form
  * Three fields: current password, new password, confirm password
  * Client-side validation for password match and length
  * Clear form on successful password change
  * Success/error message feedback
  * Independent loading states for profile vs password updates

Security Features:
- Current password verification prevents unauthorized changes
- Password hashing with bcrypt (10 salt rounds)
- Audit logging for password changes
- Same validation as registration (min 6 chars)