### PR TITLE
Add arm64 container support and fix Portainer webhook deployment

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -48,6 +48,7 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_FRONTEND }}:buildcache
@@ -69,6 +70,7 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BACKEND }}:buildcache
@@ -81,12 +83,18 @@ jobs:
     steps:
       - name: Deploy Stack via Portainer Webhook
         run: |
-          curl -X POST "${{ secrets.PORTAINER_WEBHOOK_URL }}"
+          # Call webhook with pullImage parameter to force pull latest images
+          WEBHOOK_URL="${{ secrets.PORTAINER_WEBHOOK_URL }}"
+          if [[ "$WEBHOOK_URL" == *"?"* ]]; then
+            curl -X POST "${WEBHOOK_URL}&pullImage=true"
+          else
+            curl -X POST "${WEBHOOK_URL}?pullImage=true"
+          fi
 
       - name: Wait for deployment
-        run: sleep 10
+        run: sleep 15
 
       - name: Verify deployment
         run: |
-          echo "Deployment triggered successfully"
+          echo "Deployment triggered successfully with forced image pull"
           echo "Check Portainer for deployment status"

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   backend:
     image: ghcr.io/${GITHUB_REPOSITORY:-your-username/claude_app_poc}/backend:latest
+    pull_policy: always
     container_name: asset-registration-backend
     restart: unless-stopped
     environment:
@@ -25,6 +26,7 @@ services:
 
   frontend:
     image: ghcr.io/${GITHUB_REPOSITORY:-your-username/claude_app_poc}/frontend:latest
+    pull_policy: always
     container_name: asset-registration-frontend
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Changes:
- Add multi-platform build support (linux/amd64, linux/arm64) to both frontend and backend Docker images
- Fix Portainer webhook to force pull latest images by adding pullImage=true parameter
- Add pull_policy: always to docker-compose.portainer.yml to ensure latest images are always pulled
- Increase deployment wait time from 10s to 15s to allow for image pulling

This fixes the issue where Portainer wouldn't redeploy with the latest image when using the same tag (latest).