### PR TITLE
Move Profile to separate page with routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.3.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^7.10.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import App from './App';
@@ -8,11 +9,13 @@ import theme from './theme';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </ThemeProvider>
+    <BrowserRouter>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ThemeProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
Changes:
- Installed react-router-dom for client-side routing
- Updated main.jsx with BrowserRouter wrapper
- Refactored App.jsx to use Routes and Route components
- Removed Profile from main navigation tabs
- Added Profile link to user dropdown menu in header
- Implemented route-based navigation system

Features:
✅ Profile accessible via user dropdown menu (top-right avatar) ✅ Clean URL routing (/profile, /assets, /companies, /audit, /admin) ✅ Tab navigation synced with current route
✅ Professional menu with icons and dividers
✅ Proper navigation state management

User can now:
- Click on avatar icon in top-right header
- Select "Profile" from dropdown menu
- Access profile on dedicated /profile route