### PR TITLE
Convert Company form to modal and fix Profile alignment

### DIFF
--- a/frontend/src/components/CompanyManagement.jsx
+++ b/frontend/src/components/CompanyManagement.jsx
@@ -201,15 +201,13 @@ const CompanyManagement = () => {
               Company Management ({companies.length} companies)
             </Typography>
           </Box>
-          {!showForm && (
-            <Button
-              variant="contained"
-              startIcon={<Add />}
-              onClick={() => setShowForm(true)}
-            >
-              Add Company
-            </Button>
-          )}
+          <Button
+            variant="contained"
+            startIcon={<Add />}
+            onClick={() => setShowForm(true)}
+          >
+            Add Company
+          </Button>
         </Box>
 
         {/* Success Message */}
@@ -222,67 +220,6 @@ const CompanyManagement = () => {
         {/* Error Message */}
         {error && (
           <Alert severity="error" sx={{ mb: 3 }}>{error}</Alert>
-        )}
-
-        {/* Form */}
-        {showForm && (
-          <Box sx={{ mb: 4, p: 3, bgcolor: 'background.default', borderRadius: 2 }}>
-            <Typography variant="h6" gutterBottom>
-              {editingCompany ? 'Edit Company' : 'Add New Company'}
-            </Typography>
-
-            {formError && (
-              <Alert severity="error" sx={{ mt: 2, mb: 2 }}>
-                {formError}
-              </Alert>
-            )}
-
-            <Box component="form" onSubmit={handleSubmit}>
-              <Grid container spacing={2}>
-                <Grid item xs={12}>
-                  <TextField
-                    fullWidth
-                    required
-                    id="name"
-                    name="name"
-                    label="Company Name"
-                    placeholder="Acme Corporation"
-                    value={formData.name}
-                    onChange={handleChange}
-                  />
-                </Grid>
-
-                <Grid item xs={12}>
-                  <TextField
-                    fullWidth
-                    multiline
-                    rows={3}
-                    id="description"
-                    name="description"
-                    label="Description (Optional)"
-                    placeholder="Brief description of the company..."
-                    value={formData.description}
-                    onChange={handleChange}
-                  />
-                </Grid>
-
-                <Grid item xs={12}>
-                  <Box sx={{ display: 'flex', gap: 1 }}>
-                    <Button type="submit" variant="contained">
-                      {editingCompany ? 'Update Company' : 'Add Company'}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outlined"
-                      onClick={handleCancel}
-                    >
-                      Cancel
-                    </Button>
-                  </Box>
-                </Grid>
-              </Grid>
-            </Box>
-          </Box>
         )}
 
         {/* Companies Table */}
@@ -347,6 +284,59 @@ const CompanyManagement = () => {
           </TableContainer>
         )}
       </Card>
+
+      {/* Add/Edit Company Dialog */}
+      <Dialog
+        open={showForm}
+        onClose={handleCancel}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>
+          {editingCompany ? 'Edit Company' : 'Add New Company'}
+        </DialogTitle>
+        <DialogContent>
+          {formError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {formError}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
+            <TextField
+              fullWidth
+              required
+              id="name"
+              name="name"
+              label="Company Name"
+              placeholder="Acme Corporation"
+              value={formData.name}
+              onChange={handleChange}
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              id="description"
+              name="description"
+              label="Description (Optional)"
+              placeholder="Brief description of the company..."
+              value={formData.description}
+              onChange={handleChange}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancel} variant="outlined">
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} variant="contained">
+            {editingCompany ? 'Update Company' : 'Add Company'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Delete Confirmation Dialog */}
       <Dialog

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -158,8 +158,8 @@ const Profile = () => {
       <Grid container spacing={3}>
         {/* Profile Information Card */}
         <Grid item xs={12} md={6}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
+          <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
                 <Person sx={{ mr: 1 }} color="primary" />
                 <Typography variant="h5" fontWeight={600}>
@@ -168,35 +168,33 @@ const Profile = () => {
               </Box>
 
               <Paper variant="outlined" sx={{ p: 2, mb: 3, bgcolor: 'grey.50' }}>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <Typography variant="body2" color="text.secondary">
-                      Email
-                    </Typography>
-                    <Typography variant="body1" fontWeight={600}>
-                      {user?.email}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={12}>
-                    <Typography variant="body2" color="text.secondary">
-                      Role
-                    </Typography>
-                    <Chip
-                      label={user?.role?.toUpperCase()}
-                      color={getRoleColor(user?.role)}
-                      size="small"
-                      sx={{ mt: 0.5, fontWeight: 600 }}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <Typography variant="body2" color="text.secondary">
-                      Current Name
-                    </Typography>
-                    <Typography variant="body1" fontWeight={600}>
-                      {user?.name || 'Not set'}
-                    </Typography>
-                  </Grid>
-                </Grid>
+                <Box sx={{ mb: 2 }}>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    Email
+                  </Typography>
+                  <Typography variant="body1" fontWeight={600}>
+                    {user?.email}
+                  </Typography>
+                </Box>
+                <Box sx={{ mb: 2 }}>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    Role
+                  </Typography>
+                  <Chip
+                    label={user?.role?.toUpperCase()}
+                    color={getRoleColor(user?.role)}
+                    size="small"
+                    sx={{ fontWeight: 600 }}
+                  />
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    Current Name
+                  </Typography>
+                  <Typography variant="body1" fontWeight={600}>
+                    {user?.name || 'Not set'}
+                  </Typography>
+                </Box>
               </Paper>
 
               {success && (
@@ -211,31 +209,27 @@ const Profile = () => {
                 </Alert>
               )}
 
-              <Box component="form" onSubmit={handleSubmit}>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <TextField
-                      fullWidth
-                      label="First Name"
-                      name="first_name"
-                      value={formData.first_name}
-                      onChange={handleChange}
-                      required
-                      placeholder="John"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <TextField
-                      fullWidth
-                      label="Last Name"
-                      name="last_name"
-                      value={formData.last_name}
-                      onChange={handleChange}
-                      required
-                      placeholder="Doe"
-                    />
-                  </Grid>
-                </Grid>
+              <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+                <TextField
+                  fullWidth
+                  label="First Name"
+                  name="first_name"
+                  value={formData.first_name}
+                  onChange={handleChange}
+                  required
+                  placeholder="John"
+                  sx={{ mb: 2 }}
+                />
+                <TextField
+                  fullWidth
+                  label="Last Name"
+                  name="last_name"
+                  value={formData.last_name}
+                  onChange={handleChange}
+                  required
+                  placeholder="Doe"
+                  sx={{ mb: 2 }}
+                />
 
                 <Button
                   type="submit"
@@ -243,7 +237,7 @@ const Profile = () => {
                   fullWidth
                   disabled={loading}
                   startIcon={loading ? <CircularProgress size={20} /> : <Save />}
-                  sx={{ mt: 3 }}
+                  sx={{ mt: 'auto' }}
                 >
                   {loading ? 'Updating...' : 'Update Profile'}
                 </Button>
@@ -254,8 +248,8 @@ const Profile = () => {
 
         {/* Change Password Card */}
         <Grid item xs={12} md={6}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
+          <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
                 <Lock sx={{ mr: 1 }} color="primary" />
                 <Typography variant="h5" fontWeight={600}>
@@ -275,7 +269,7 @@ const Profile = () => {
                 </Alert>
               )}
 
-              <Box component="form" onSubmit={handlePasswordSubmit}>
+              <Box component="form" onSubmit={handlePasswordSubmit} sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
                 <TextField
                   fullWidth
                   type="password"
@@ -311,7 +305,7 @@ const Profile = () => {
                   required
                   placeholder="Confirm new password"
                   inputProps={{ minLength: 6 }}
-                  sx={{ mb: 3 }}
+                  sx={{ mb: 2 }}
                 />
 
                 <Button
@@ -320,6 +314,7 @@ const Profile = () => {
                   fullWidth
                   disabled={passwordLoading}
                   startIcon={passwordLoading ? <CircularProgress size={20} /> : <Lock />}
+                  sx={{ mt: 'auto' }}
                 >
                   {passwordLoading ? 'Changing Password...' : 'Change Password'}
                 </Button>


### PR DESCRIPTION
Company Management:
- Changed Add/Edit Company form from inline to modal dialog
- Matches the pattern used in Asset Registration
- Cleaner UI with modal overlay
- Form now appears in a Dialog instead of expanding inline

Profile Page:
- Fixed card alignment with flexbox layout
- Both cards now have equal heights and proper spacing
- Replaced Grid inside Paper with Box for cleaner structure
- Submit buttons now stay at bottom with mt: 'auto'
- Consistent spacing throughout both cards