### PR TITLE
Fix OIDC integration and database migration issues

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -157,7 +157,7 @@ const initDb = () => {
 
   // Migration: Add oidc_sub column for OIDC authentication
   try {
-    db.exec('ALTER TABLE users ADD COLUMN oidc_sub TEXT UNIQUE');
+    db.exec('ALTER TABLE users ADD COLUMN oidc_sub TEXT');
   } catch (e) {
     // Column already exists
   }
@@ -171,7 +171,13 @@ const initDb = () => {
   db.exec('CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_logs(timestamp)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_audit_entity ON audit_logs(entity_type, entity_id)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_user_email ON users(email)');
-  db.exec('CREATE INDEX IF NOT EXISTS idx_user_oidc_sub ON users(oidc_sub)');
+
+  // Create unique index for oidc_sub (handles uniqueness constraint)
+  try {
+    db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_user_oidc_sub ON users(oidc_sub) WHERE oidc_sub IS NOT NULL');
+  } catch (e) {
+    // Index already exists
+  }
 
   console.log('Database initialized successfully');
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -441,7 +441,7 @@ app.get('/api/auth/oidc/config', (req, res) => {
 });
 
 // Initiate OIDC login
-app.get('/api/auth/oidc/login', (req, res) => {
+app.get('/api/auth/oidc/login', async (req, res) => {
   try {
     if (!isOIDCEnabled()) {
       return res.status(503).json({ error: 'OIDC is not enabled' });
@@ -463,7 +463,7 @@ app.get('/api/auth/oidc/login', (req, res) => {
       }
     }
 
-    const authUrl = getAuthorizationUrl(state);
+    const authUrl = await getAuthorizationUrl(state);
     res.json({ authUrl, state });
   } catch (error) {
     console.error('OIDC login init error:', error);


### PR DESCRIPTION
This commit resolves the backend startup failure caused by openid-client v6 API incompatibility and SQLite UNIQUE constraint limitations.

Changes:
- Updated backend/oidc.js to use openid-client v6 API:
  - Changed from 'Issuer' and 'generators' exports to namespace import 'client'
  - Updated initializeOIDC() to use client.discovery()
  - Made getAuthorizationUrl() async using client.randomPKCECodeVerifier()
  - Updated handleCallback() to use client.authorizationCodeGrant()
  - Updated getUserInfo() to use client.fetchUserInfo()
  - Fixed isOIDCEnabled() to check config !== null

- Fixed backend/database.js migration:
  - Removed UNIQUE constraint from ALTER TABLE ADD COLUMN (not supported by SQLite on existing tables)
  - Created separate UNIQUE INDEX with WHERE clause for oidc_sub column
  - Allows NULL values while enforcing uniqueness on non-NULL values

- Updated backend/server.js:
  - Made /api/auth/oidc/login endpoint async to properly await getAuthorizationUrl()

The backend now starts successfully with OIDC properly disabled by default and regular email/password authentication working correctly.