### PR TITLE
Fix asset creation route async handler

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -915,7 +915,7 @@ app.get('/api/assets/search', async (req, res) => {
 });
 
 // Create new asset
-app.post('/api/assets', authenticate, (req, res) => {
+app.post('/api/assets', authenticate, async (req, res) => {
   try {
     const { employee_name, employee_email, manager_name, manager_email, client_name, laptop_serial_number, laptop_asset_tag, notes } = req.body;
 


### PR DESCRIPTION
## Summary
- mark the asset creation API route handler as async so await works correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693083e562cc8321881e4dafc8f39e6f)