### PR TITLE
Add SQLite import workflow for PostgreSQL

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "openid-client": "^6.8.1",
     "pg": "^8.11.3",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Summary
- add backend endpoint to upload and import SQLite assets.db data into PostgreSQL and reset sequences
- include import helper that migrates assets, companies, users, and audit logs from SQLite backups
- surface an admin UI control in PostgreSQL settings to upload a SQLite file and start the import

## Testing
- npm --no-progress run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693085b119dc832191f3af673f525be8)