### PR TITLE
Add CSV bulk import flows for assets and companies

### DIFF
--- a/frontend/public/import_assets.csv
+++ b/frontend/public/import_assets.csv
@@ -1,0 +1,3 @@
+employee_name,employee_email,manager_name,manager_email,client_name,laptop_make,laptop_model,laptop_serial_number,laptop_asset_tag,status,notes
+Jane Doe,jane.doe@example.com,John Manager,john.manager@example.com,Acme Corp,Lenovo,ThinkPad T14,ABC12345,AT-1001,active,Primary laptop issued Q1
+Sam Smith,sam.smith@example.com,John Manager,john.manager@example.com,Globex Inc,Apple,MacBook Pro,XYZ98765,AT-1002,returned,Returned after project completion

--- a/frontend/public/import_companies.csv
+++ b/frontend/public/import_companies.csv
@@ -1,0 +1,4 @@
+name,description
+Acme Corp,Example technology customer
+Globex Inc,Consulting partner organization
+Initech,Software firm with distributed teams


### PR DESCRIPTION
## Summary
- add backend CSV parsers and new asset/company bulk import endpoints with validation and audit logging
- provide UI controls in asset and company management to upload CSVs and download example templates
- include sample import_assets.csv and import_companies.csv files for users

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308bcdb3dc832190f0189f3459060a)