### PR TITLE
Ensure filter dropdown labels remain visible

### DIFF
--- a/frontend/src/components/AssetList.jsx
+++ b/frontend/src/components/AssetList.jsx
@@ -339,7 +339,7 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
               />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-              <FormControl fullWidth size="small">
+              <FormControl fullWidth size="small" sx={{ minWidth: 180 }}>
                 <InputLabel>Status</InputLabel>
                 <Select
                   name="status"

--- a/frontend/src/components/AuditReporting.jsx
+++ b/frontend/src/components/AuditReporting.jsx
@@ -281,7 +281,7 @@ const AuditReporting = () => {
             </Box>
             <Grid container spacing={2}>
               <Grid item xs={12} sm={6} md={4} lg={2}>
-                <FormControl fullWidth size="small">
+                <FormControl fullWidth size="small" sx={{ minWidth: 180 }}>
                   <InputLabel>Action</InputLabel>
                   <Select
                     name="action"
@@ -299,7 +299,7 @@ const AuditReporting = () => {
               </Grid>
 
               <Grid item xs={12} sm={6} md={4} lg={2}>
-                <FormControl fullWidth size="small">
+                <FormControl fullWidth size="small" sx={{ minWidth: 180 }}>
                   <InputLabel>Entity Type</InputLabel>
                   <Select
                     name="entityType"
@@ -354,7 +354,7 @@ const AuditReporting = () => {
               </Grid>
 
               <Grid item xs={12} sm={6} md={4} lg={2}>
-                <FormControl fullWidth size="small">
+                <FormControl fullWidth size="small" sx={{ minWidth: 180 }}>
                   <InputLabel>Limit</InputLabel>
                   <Select
                     name="limit"


### PR DESCRIPTION
## Summary
- add minimum width styling to filter dropdowns so their labels remain readable
- align audit log filter controls with the same sizing to avoid truncation

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309672854c832187ea3a6e5bd22874)