### PR TITLE
Fix test suite configuration issues

### DIFF
--- a/backend/auth.test.js
+++ b/backend/auth.test.js
@@ -1,10 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import { generateToken, verifyToken, hashPassword, comparePassword } from './auth.js';
-
-// Mock the database module
-vi.mock('./database.js', () => ({
-  userDb: {},
-}));
 
 describe('Auth Module', () => {
   describe('generateToken', () => {

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,6 @@
 export default {
   testEnvironment: 'node',
   transform: {},
-  extensionsToTreatAsEsm: ['.js'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/backend/mfa.test.js
+++ b/backend/mfa.test.js
@@ -20,7 +20,8 @@ describe('MFA Module', () => {
       expect(result.qrCode).toMatch(/^data:image\/png;base64,/);
       expect(result.otpauthUrl).toBeDefined();
       expect(result.otpauthUrl).toContain('otpauth://totp/');
-      expect(result.otpauthUrl).toContain(userEmail);
+      // Email is URL-encoded in the otpauth URL
+      expect(decodeURIComponent(result.otpauthUrl)).toContain(userEmail);
     });
 
     it('should include custom issuer in otpauth URL', async () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,5 +24,11 @@ export default defineConfig({
         'src/test/',
       ],
     },
+    // Suppress console warnings during tests
+    onConsoleLog(log, type) {
+      if (type === 'stderr' && log.includes('Warning: An update to')) {
+        return false;
+      }
+    },
   },
 });


### PR DESCRIPTION
- Remove extensionsToTreatAsEsm from Jest config (already inferred from package.json type)
- Remove unused vi import and mock from auth.test.js (Jest doesn't have vi)
- Fix URL encoding check in MFA test for otpauth URLs
- Suppress React act() warnings in Vitest config for cleaner CI output