### PR TITLE
Fix asset endpoint manager validation bug

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -94,6 +94,12 @@ app.post('/api/auth/register', async (req, res) => {
       });
     }
 
+    if (!manager_name || !manager_email) {
+      return res.status(400).json({
+        error: 'Manager name and manager email are required'
+      });
+    }
+
     // Check if user already exists
     const existingUser = await userDb.getByEmail(email);
     if (existingUser) {
@@ -124,8 +130,8 @@ app.post('/api/auth/register', async (req, res) => {
       name: name || `${first_name} ${last_name}`,
       first_name: first_name || null,
       last_name: last_name || null,
-      manager_name: manager_name || null,
-      manager_email: manager_email || null,
+      manager_name,
+      manager_email,
       role: userRole
     });
 
@@ -276,6 +282,12 @@ app.put('/api/auth/profile', authenticate, async (req, res) => {
       });
     }
 
+    if (!manager_name || !manager_email) {
+      return res.status(400).json({
+        error: 'Manager name and manager email are required'
+      });
+    }
+
     // Get old profile data for audit
     const oldUser = await userDb.getById(req.user.id);
 
@@ -287,8 +299,8 @@ app.put('/api/auth/profile', authenticate, async (req, res) => {
       name,
       first_name,
       last_name,
-      manager_name: manager_name || null,
-      manager_email: manager_email || null
+      manager_name,
+      manager_email
     });
 
     // Get updated user

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -22,7 +22,9 @@ const Profile = () => {
   const { user, getAuthHeaders, updateUser } = useAuth();
   const [formData, setFormData] = useState({
     first_name: '',
-    last_name: ''
+    last_name: '',
+    manager_name: '',
+    manager_email: ''
   });
   const [passwordData, setPasswordData] = useState({
     currentPassword: '',
@@ -50,7 +52,9 @@ const Profile = () => {
     if (user) {
       setFormData({
         first_name: user.first_name || '',
-        last_name: user.last_name || ''
+        last_name: user.last_name || '',
+        manager_name: user.manager_name || '',
+        manager_email: user.manager_email || ''
       });
     }
   }, [user]);
@@ -293,6 +297,22 @@ const Profile = () => {
                     {user?.name || 'Not set'}
                   </Typography>
                 </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    Manager Name
+                  </Typography>
+                  <Typography variant="body1" fontWeight={600}>
+                    {user?.manager_name || 'Not set'}
+                  </Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" gutterBottom>
+                    Manager Email
+                  </Typography>
+                  <Typography variant="body1" fontWeight={600}>
+                    {user?.manager_email || 'Not set'}
+                  </Typography>
+                </Box>
               </Box>
             </Card>
           </Grid>
@@ -304,7 +324,7 @@ const Profile = () => {
                 Update Profile
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                Update your first and last name. Your email address cannot be changed.
+                Update your personal information and manager details. Your email address cannot be changed.
               </Typography>
 
               {error && (
@@ -332,6 +352,27 @@ const Profile = () => {
                   onChange={handleChange}
                   required
                   placeholder="Doe"
+                  sx={{ mb: 2 }}
+                />
+                <TextField
+                  fullWidth
+                  label="Manager Name"
+                  name="manager_name"
+                  value={formData.manager_name}
+                  onChange={handleChange}
+                  required
+                  placeholder="Jane Smith"
+                  sx={{ mb: 2 }}
+                />
+                <TextField
+                  fullWidth
+                  label="Manager Email"
+                  name="manager_email"
+                  type="email"
+                  value={formData.manager_email}
+                  onChange={handleChange}
+                  required
+                  placeholder="manager@company.com"
                   sx={{ mb: 2 }}
                 />
 

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -151,6 +151,7 @@ const Register = ({ onSwitchToLogin }) => {
                   name="manager_name"
                   value={formData.manager_name}
                   onChange={handleChange}
+                  required
                   placeholder="Jane Smith"
                 />
               </Grid>
@@ -162,6 +163,7 @@ const Register = ({ onSwitchToLogin }) => {
                   type="email"
                   value={formData.manager_email}
                   onChange={handleChange}
+                  required
                   placeholder="manager@company.com"
                 />
               </Grid>


### PR DESCRIPTION
The asset endpoint requires manager_name and manager_email in the user record but registration and profile treated these as optional, breaking asset creation for users without manager data.

Backend changes:
- Add validation requiring manager_name and manager_email in /auth/register endpoint
- Add validation requiring manager_name and manager_email in /auth/profile endpoint
- Remove null fallbacks when storing manager fields since they're now required

Frontend changes:
- Make manager fields required in registration form (Register.jsx)
- Add manager fields to Profile component state and initialization
- Display manager information in Account Information section
- Add editable manager fields to Update Profile form
- Update form description to mention manager details

This ensures all users have manager data populated, allowing asset creation to work correctly for all employees.