### PR TITLE
Auto-assign manager role during employee registration

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -729,6 +729,7 @@ export const userDb = {
   getByEmail: async (email) => dbGet('SELECT * FROM users WHERE email = ?', [email]),
   getById: async (id) => dbGet('SELECT * FROM users WHERE id = ?', [id]),
   getAll: async () => dbAll('SELECT * FROM users ORDER BY created_at DESC'),
+  getByManagerEmail: async (managerEmail) => dbAll('SELECT * FROM users WHERE manager_email = ?', [managerEmail]),
   updateRole: async (id, role) => dbRun('UPDATE users SET role = ? WHERE id = ?', [role, id]),
   updateLastLogin: async (id) => {
     const now = new Date().toISOString();


### PR DESCRIPTION
This change implements automatic manager role assignment in two scenarios:

1. When an employee registers and specifies a manager_email that matches an existing user, that user is automatically assigned the manager role (if not already a manager or admin).

2. When a user registers and there are already employees with their email as manager_email, the new user is automatically assigned the manager role.

Changes:
- Added getByManagerEmail() function to userDb to query users by manager_email
- Created autoAssignManagerRole() helper function to handle role assignment logic
- Updated registration endpoint to check both scenarios and auto-assign roles
- Added comprehensive audit logging for auto-assigned role changes

This ensures that managers are automatically granted appropriate permissions based on their actual organizational relationships without manual admin intervention.