### PR TITLE
Auto-assign manager role during employee profile manager update

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -465,6 +465,16 @@ app.put('/api/auth/profile', authenticate, async (req, res) => {
       }
     }
 
+    // Auto-assign manager role if manager_email changed
+    if (managerChanged && manager_email && oldUser.manager_email !== manager_email) {
+      try {
+        await autoAssignManagerRole(manager_email, user.email);
+      } catch (roleError) {
+        console.error('Error auto-assigning manager role during profile update:', roleError);
+        // Don't fail profile update if role assignment fails
+      }
+    }
+
     res.json({
       message: 'Profile updated successfully',
       user: {


### PR DESCRIPTION
- Added automatic manager role assignment when an employee updates their manager
- If the new manager is not already a manager or admin, they are automatically assigned the manager role
- Uses existing autoAssignManagerRole function for consistency
- Only triggers when manager_email changes to a different value
- Follows same pattern as registration flow
- Errors are logged but don't fail the profile update