### PR TITLE
Handle passkey registration userID as BufferSource

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -802,7 +802,8 @@ app.post('/api/auth/passkeys/registration-options', authenticate, async (req, re
       rpID,
       userName: req.user.email,
       userDisplayName: req.user.name || req.user.email,
-      userID: req.user.id.toString(),
+      // simplewebauthn requires userID to be a BufferSource (not string)
+      userID: Buffer.from(req.user.id.toString()),
       attestationType: 'none',
       authenticatorSelection: {
         residentKey: 'preferred',


### PR DESCRIPTION
## Summary
- update passkey registration to provide BufferSource userID compatible with latest simplewebauthn requirements

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311e16827083218279fe5ca2e58dca)