### PR TITLE
Handle missing WebAuthn base64 values safely

### DIFF
--- a/frontend/src/utils/webauthn.js
+++ b/frontend/src/utils/webauthn.js
@@ -1,5 +1,18 @@
-export const base64UrlToUint8Array = (value) =>
-  Uint8Array.from(atob(value.replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+export const base64UrlToUint8Array = (value) => {
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error('Invalid WebAuthn value: expected a base64url string or byte array');
+  }
+
+  return Uint8Array.from(atob(value.replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+};
 
 export const uint8ArrayToBase64Url = (buffer) =>
   btoa(String.fromCharCode(...new Uint8Array(buffer)))
@@ -9,12 +22,12 @@ export const uint8ArrayToBase64Url = (buffer) =>
 
 export const prepareCreationOptions = (options) => ({
   ...options,
-  challenge: base64UrlToUint8Array(options.challenge),
+  challenge: base64UrlToUint8Array(options?.challenge),
   user: {
-    ...options.user,
-    id: base64UrlToUint8Array(options.user.id)
+    ...options?.user,
+    id: base64UrlToUint8Array(options?.user?.id)
   },
-  excludeCredentials: (options.excludeCredentials || []).map((cred) => ({
+  excludeCredentials: (options?.excludeCredentials || []).map((cred) => ({
     ...cred,
     id: base64UrlToUint8Array(cred.id)
   }))
@@ -22,8 +35,8 @@ export const prepareCreationOptions = (options) => ({
 
 export const prepareRequestOptions = (options) => ({
   ...options,
-  challenge: base64UrlToUint8Array(options.challenge),
-  allowCredentials: (options.allowCredentials || []).map((cred) => ({
+  challenge: base64UrlToUint8Array(options?.challenge),
+  allowCredentials: (options?.allowCredentials || []).map((cred) => ({
     ...cred,
     id: base64UrlToUint8Array(cred.id)
   }))


### PR DESCRIPTION
## Summary
- add validation around WebAuthn base64 conversions to avoid undefined property access
- guard preparation of WebAuthn creation and request options to handle missing fields more safely

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693120ca7b0883218859fdb33a3ad7dc)