### PR TITLE
Fix duplicate credential variable declaration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -863,10 +863,10 @@ app.post('/api/auth/passkeys/verify-registration', authenticate, async (req, res
 
     // In SimpleWebAuthn v10+, the structure changed
     // registrationInfo now has a 'credential' object containing id and publicKey
-    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-    const credentialID = credential.id;
-    const credentialPublicKey = credential.publicKey;
-    const counter = credential.counter;
+    const { credential: registeredCredential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const credentialID = registeredCredential.id;
+    const credentialPublicKey = registeredCredential.publicKey;
+    const counter = registeredCredential.counter;
 
     console.log('[Passkey Registration] Extracted data:', {
       credentialIDLength: credentialID?.length || 0,


### PR DESCRIPTION
The previous fix introduced a duplicate declaration of the 'credential' variable, causing a SyntaxError at server startup. Renamed the second occurrence to 'registeredCredential' to resolve the conflict.