### PR TITLE
Fix passkey registration credential extraction for SimpleWebAuthn v10+

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -862,11 +862,8 @@ app.post('/api/auth/passkeys/verify-registration', authenticate, async (req, res
     }
 
     // In SimpleWebAuthn v10+, the structure changed
-    // registrationInfo now has a 'credential' object containing id and publicKey
-    const { credential: registeredCredential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-    const credentialID = registeredCredential.id;
-    const credentialPublicKey = registeredCredential.publicKey;
-    const counter = registeredCredential.counter;
+    // Properties are directly on registrationInfo, not nested under 'credential'
+    const { credentialID, credentialPublicKey, counter, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
 
     console.log('[Passkey Registration] Extracted data:', {
       credentialIDLength: credentialID?.length || 0,


### PR DESCRIPTION
The code was incorrectly trying to extract credential data from a nested 'credential' object that doesn't exist in SimpleWebAuthn v10+. In v10+, the credentialID, credentialPublicKey, and counter properties are directly on registrationInfo, not nested under a credential property.

This was causing undefined values to be passed to the database, resulting in empty credential_id being saved and subsequent validation failures.

Fixes the issue where passkeys were being registered with empty credential_id values and then immediately deleted as corrupted.