### PR TITLE
Fix postgres healthcheck database selection

### DIFF
--- a/docker-compose.portainer-postgres.yml
+++ b/docker-compose.portainer-postgres.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - asset-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ars_app}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ars_app} -d ${POSTGRES_DB:-ars}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the Postgres healthcheck to target the configured database name so readiness checks do not fail when the default database differs from the user

## Testing
- not run (configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931beedc73c8321a8b4d494a3608ea8)