### PR TITLE
Add KARS branding and profile photo support

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
-# Deployment Guide - Asset Registration System
+# Deployment Guide - KeyData Asset Registration System (KARS)
 
-This guide explains how to deploy the Asset Registration System to Portainer using GitHub Actions with Cloudflare tunnel support for hosting at `assets.jvhlabs.com`.
+This guide explains how to deploy KARS to Portainer using GitHub Actions with Cloudflare tunnel support for hosting at `kars.jvhlabs.com`.
 
 ## Table of Contents
 1. [Prerequisites](#prerequisites)

--- a/QUICKSTART-PORTAINER.md
+++ b/QUICKSTART-PORTAINER.md
@@ -1,11 +1,11 @@
 # Quick Start - Portainer Deployment
 
-Get your Asset Registration System running on Portainer in minutes!
+Get your KeyData Asset Registration System (KARS) running on Portainer in minutes!
 
 ## Prerequisites
 - Portainer instance running
 - GitHub account
-- Cloudflare account (for assets.jvhlabs.com)
+- Cloudflare account (for kars.jvhlabs.com)
 
 ## 5-Minute Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ARS (Asset Registration System)
+# KARS (KeyData Asset Registration System)
 
 [![GitHub Actions](https://img.shields.io/badge/CI%2FCD-GitHub%20Actions-2088FF?logo=github-actions&logoColor=white)](https://github.com/humac/claude_app_poc/actions)
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
@@ -6,7 +6,7 @@
 
 A comprehensive SOC2-compliant web application for tracking and managing client assets assigned to consultants, with full authentication, role-based access control, and automated deployment.
 
-🌐 **Live Demo:** [https://ars.jvhlabs.com](https://ars.jvhlabs.com)
+🌐 **Live Demo:** [https://kars.jvhlabs.com](https://kars.jvhlabs.com)
 
 📖 **Documentation:** [View Wiki](../../wiki)
 
@@ -30,7 +30,7 @@ A comprehensive SOC2-compliant web application for tracking and managing client 
 - **Role-Based Access Control** - Three roles: Employee, Manager, Admin
 - **Automatic Manager Promotion** - Users listed as a manager are auto-promoted to manager with audit logging
 - **First Admin Setup** - Automatic admin promotion for first user
-- **Profile Management** - Update first/last name, password, and MFA settings
+- **Profile Management** - Update first/last name, password, MFA settings, and profile photos
 
 ### 📦 Asset Management
 - **Self-Service Registration** - Consultants register client laptops
@@ -88,7 +88,7 @@ Docker images are automatically built for both platforms during CI/CD.
 
 ```bash
 # 1. Access the application
-https://ars.jvhlabs.com
+https://kars.jvhlabs.com
 
 # 2. Register (first user becomes admin!)
 Click "Register" → Fill form → Auto-login

--- a/backend/mfa.js
+++ b/backend/mfa.js
@@ -3,7 +3,7 @@ import QRCode from 'qrcode';
 import crypto from 'crypto';
 
 // Generate MFA secret and QR code
-export async function generateMFASecret(userEmail, issuer = 'ARS') {
+export async function generateMFASecret(userEmail, issuer = 'KARS') {
   const secret = speakeasy.generateSecret({
     name: `${issuer} (${userEmail})`,
     issuer: issuer,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ars-backend",
   "version": "1.0.0",
-  "description": "Backend API for ARS - Asset Registration System",
+  "description": "Backend API for KARS - KeyData Asset Registration System",
   "main": "server.js",
   "type": "module",
   "scripts": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ARS - Asset Registration System</title>
+    <title>KARS - KeyData Asset Registration System</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ars-frontend",
   "version": "1.0.0",
-  "description": "Frontend for ARS - Asset Registration System",
+  "description": "Frontend for KARS - KeyData Asset Registration System",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -125,7 +125,7 @@ function App() {
         <Toolbar>
           <Box sx={{ flexGrow: 1 }}>
             <Typography variant="h6" component="div" fontWeight={600}>
-              ARS - Asset Registration System
+              KARS - KeyData Asset Registration System
             </Typography>
             <Typography variant="body2" sx={{ opacity: 0.9 }}>
               SOC2 Compliance - Track and manage client assets

--- a/frontend/src/AppNew.jsx
+++ b/frontend/src/AppNew.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import {
@@ -96,7 +96,7 @@ function AppNew() {
               <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary">
                 <Laptop className="h-4 w-4 text-primary-foreground" />
               </div>
-              <span className="font-semibold text-lg hidden sm:block">ARS</span>
+              <span className="font-semibold text-lg hidden sm:block">KARS</span>
             </div>
 
             {/* Desktop Navigation */}
@@ -129,6 +129,9 @@ function AppNew() {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="rounded-full">
                   <Avatar className="h-8 w-8">
+                    {user?.profile_image && (
+                      <AvatarImage src={user.profile_image} alt="Profile" />
+                    )}
                     <AvatarFallback className="bg-primary text-primary-foreground">
                       {user?.first_name?.charAt(0)}
                     </AvatarFallback>
@@ -168,17 +171,20 @@ function AppNew() {
         </div>
 
         {/* Mobile Menu */}
-        {mobileMenuOpen && (
-          <div className="md:hidden border-t bg-background">
-            <div className="container mx-auto py-4 space-y-4">
-              {/* User Info */}
-              <div className="flex items-center gap-3 pb-4 border-b">
-                <Avatar className="h-10 w-10">
-                  <AvatarFallback className="bg-primary text-primary-foreground">
-                    {user?.first_name?.charAt(0)}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
+            {mobileMenuOpen && (
+              <div className="md:hidden border-t bg-background">
+                <div className="container mx-auto py-4 space-y-4">
+                  {/* User Info */}
+                  <div className="flex items-center gap-3 pb-4 border-b">
+                    <Avatar className="h-10 w-10">
+                      {user?.profile_image && (
+                        <AvatarImage src={user.profile_image} alt="Profile" />
+                      )}
+                      <AvatarFallback className="bg-primary text-primary-foreground">
+                        {user?.first_name?.charAt(0)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1">
                   <p className="font-medium">{user?.first_name} {user?.last_name}</p>
                   <p className="text-sm text-muted-foreground">{user?.email}</p>
                 </div>
@@ -242,7 +248,7 @@ function AppNew() {
       {/* Footer */}
       <footer className="border-t py-4 mt-auto">
         <div className="container mx-auto text-center text-sm text-muted-foreground">
-          SOC2 Compliance - Asset Registration System
+          SOC2 Compliance - KeyData Asset Registration System
         </div>
       </footer>
     </div>

--- a/frontend/src/components/AdminSettings.jsx
+++ b/frontend/src/components/AdminSettings.jsx
@@ -546,7 +546,7 @@ const AdminSettings = () => {
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
                 <Box>
                   <Typography variant="body2" color="text.secondary">
-                    <strong>Application:</strong> ARS - Asset Registration System
+                    <strong>Application:</strong> KARS - KeyData Asset Registration System
                   </Typography>
                 </Box>
                 <Box>

--- a/frontend/src/components/AdminSettingsNew.jsx
+++ b/frontend/src/components/AdminSettingsNew.jsx
@@ -286,7 +286,7 @@ const AdminSettingsNew = () => {
               <Card>
                 <CardHeader><CardTitle className="text-base">System Information</CardTitle></CardHeader>
                 <CardContent className="space-y-2 text-sm text-muted-foreground">
-                  <p><strong>Application:</strong> ARS - Asset Registration System</p>
+                  <p><strong>Application:</strong> KARS - KeyData Asset Registration System</p>
                   <p><strong>Purpose:</strong> SOC2 Compliance - Track and manage client assets</p>
                   <p><strong>Features:</strong> Role-based access, Asset tracking, Company management, Audit logging, CSV exports</p>
                 </CardContent>
@@ -339,7 +339,7 @@ const AdminSettingsNew = () => {
               <Card>
                 <CardHeader>
                   <CardTitle className="text-base">Company Logo</CardTitle>
-                  <CardDescription>Upload a custom logo to replace the default ARS branding on the login page.</CardDescription>
+                  <CardDescription>Upload a custom logo to replace the default KARS branding on the login page.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   {brandingLoading ? (

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -278,7 +278,7 @@ const Login = ({ onSwitchToRegister }) => {
           ) : (
             <>
               <Typography variant="h5" fontWeight={600} gutterBottom>
-                ARS - Asset Registration System
+                KARS - KeyData Asset Registration System
               </Typography>
               <Typography variant="body2" sx={{ opacity: 0.9 }}>
                 Sign in to manage client assets

--- a/frontend/src/components/Login.test.jsx
+++ b/frontend/src/components/Login.test.jsx
@@ -32,7 +32,7 @@ describe('Login Component', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('ARS - Asset Registration System')).toBeInTheDocument();
+      expect(screen.getByText('KARS - KeyData Asset Registration System')).toBeInTheDocument();
     });
 
     expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();

--- a/frontend/src/components/LoginNew.jsx
+++ b/frontend/src/components/LoginNew.jsx
@@ -241,8 +241,8 @@ const LoginNew = ({ onSwitchToRegister }) => {
               <div className="inline-flex items-center justify-center w-16 h-16 rounded-xl bg-primary mb-4">
                 <Laptop className="h-8 w-8 text-primary-foreground" />
               </div>
-              <h1 className="text-2xl font-bold text-foreground">ARS</h1>
-              <p className="text-muted-foreground">Asset Registration System</p>
+              <h1 className="text-2xl font-bold text-foreground">KARS</h1>
+              <p className="text-muted-foreground">KeyData Asset Registration System</p>
             </>
           )}
         </div>

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -88,7 +88,7 @@ const Register = ({ onSwitchToLogin }) => {
           }}
         >
           <Typography variant="h5" fontWeight={600} gutterBottom>
-            ARS - Asset Registration System
+            KARS - KeyData Asset Registration System
           </Typography>
           <Typography variant="body2" sx={{ opacity: 0.9 }}>
             Create an account to get started

--- a/frontend/src/components/RegisterNew.jsx
+++ b/frontend/src/components/RegisterNew.jsx
@@ -72,8 +72,8 @@ const RegisterNew = ({ onSwitchToLogin }) => {
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-xl bg-primary mb-4">
             <Laptop className="h-8 w-8 text-primary-foreground" />
           </div>
-          <h1 className="text-2xl font-bold text-foreground">ARS</h1>
-          <p className="text-muted-foreground">Asset Registration System</p>
+          <h1 className="text-2xl font-bold text-foreground">KARS</h1>
+          <p className="text-muted-foreground">KeyData Asset Registration System</p>
         </div>
 
         <Card className="shadow-lg">

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,11 +1,11 @@
 # API Reference
 
-Complete REST API documentation for the Asset Registration System.
+Complete REST API documentation for the KeyData Asset Registration System (KARS).
 
 ## Base URL
 
 - **Development:** `http://localhost:3001/api`
-- **Production:** `https://assets.jvhlabs.com/api`
+- **Production:** `https://kars.jvhlabs.com/api`
 
 ## Authentication
 

--- a/wiki/Deployment-Guide.md
+++ b/wiki/Deployment-Guide.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-Complete production deployment guide for the Asset Registration System.
+Complete production deployment guide for the KeyData Asset Registration System (KARS).
 
 > **Quick Start:** For a condensed version, see [QUICKSTART-PORTAINER.md](../QUICKSTART-PORTAINER.md) in the repository.
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,6 +1,6 @@
 # Features
 
-Complete feature overview of the Asset Registration System.
+Complete feature overview of the KeyData Asset Registration System (KARS).
 
 ## 🎯 Core Features
 
@@ -84,6 +84,7 @@ Complete feature overview of the Asset Registration System.
 **Profile Management**
 - Update first name and last name
 - View current role and email
+- Upload and manage a personal profile photo for the header avatar
 - Change password with current password verification
 - Color-coded role badge display
 - MFA enrollment status display

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
-# Asset Registration System Wiki
+# KARS (KeyData Asset Registration System) Wiki
 
-Welcome to the comprehensive documentation for the **Client Asset Registration System** - a SOC2-compliant application for tracking and managing client laptops assigned to consultants.
+Welcome to the comprehensive documentation for the **KeyData Asset Registration System (KARS)** - a SOC2-compliant application for tracking and managing client laptops assigned to consultants.
 
 ## 🎯 Overview
 

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -1,13 +1,13 @@
 # Quick Start Guide
 
-Get the Asset Registration System running in 5 minutes!
+Get the KeyData Asset Registration System (KARS) running in 5 minutes!
 
 ## For Users
 
 ### First Time Setup
 
 1. **Access the Application**
-   - Navigate to: `https://assets.jvhlabs.com`
+   - Navigate to: `https://kars.jvhlabs.com`
    - Or your deployed URL
 
 2. **Register Your Account**


### PR DESCRIPTION
## Summary
- rebrand the app as KARS, updating UI labels, documentation, and URLs to kars.jvhlabs.com
- add profile photo upload/display support in profile settings and header avatars
- extend backend schema and API to store validated profile images

## Testing
- npm test -- --runInBand (backend)
- npm test (frontend) *(fails: missing tailwindcss dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c8616ba083218206310c0b227af0)