### PR TITLE
Add Security tab with Passkey configuration to AdminSettingsNew

### DIFF
--- a/frontend/src/components/AdminSettingsNew.jsx
+++ b/frontend/src/components/AdminSettingsNew.jsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog';
 import { Settings, Users, LayoutDashboard, Database, Key, Trash2, Loader2, AlertTriangle, Shield, Image } from 'lucide-react';
 import OIDCSettings from './OIDCSettings';
+import SecuritySettings from './SecuritySettings';
 
 const AdminSettingsNew = () => {
   const { getAuthHeaders, user } = useAuth();
@@ -217,6 +218,7 @@ const AdminSettingsNew = () => {
               <TabsTrigger value="overview" className="gap-2"><LayoutDashboard className="h-4 w-4" />Overview</TabsTrigger>
               <TabsTrigger value="settings" className="gap-2"><Database className="h-4 w-4" />Database</TabsTrigger>
               <TabsTrigger value="branding" className="gap-2"><Image className="h-4 w-4" />Branding</TabsTrigger>
+              <TabsTrigger value="security" className="gap-2"><Shield className="h-4 w-4" />Security</TabsTrigger>
               <TabsTrigger value="oidc" className="gap-2"><Key className="h-4 w-4" />OIDC/SSO</TabsTrigger>
             </TabsList>
 
@@ -386,6 +388,10 @@ const AdminSettingsNew = () => {
                   )}
                 </CardContent>
               </Card>
+            </TabsContent>
+
+            <TabsContent value="security">
+              <SecuritySettings />
             </TabsContent>
 
             <TabsContent value="oidc">


### PR DESCRIPTION
- Import SecuritySettings component
- Add Security tab between Branding and OIDC/SSO tabs
- Use Shield icon for Security tab
- Render SecuritySettings component in security TabsContent

This restores the passkey configuration UI that was previously only available in AdminSettings.jsx. Since the app uses AppNew.jsx which imports AdminSettingsNew.jsx, the Security tab is now visible.

Fixes the issue where users couldn't access passkey settings because they were only implemented in the Material-UI version (AdminSettings.jsx) but not in the shadcn/ui version (AdminSettingsNew.jsx).