### PR TITLE
Convert OIDC settings to shadcn/ui styling for consistency

### DIFF
--- a/frontend/src/components/OIDCSettingsNew.jsx
+++ b/frontend/src/components/OIDCSettingsNew.jsx
@@ -1,0 +1,281 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Separator } from '@/components/ui/separator';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader2, Save } from 'lucide-react';
+
+const OIDCSettingsNew = () => {
+  const { getAuthHeaders } = useAuth();
+  const { toast } = useToast();
+  const [settings, setSettings] = useState({
+    enabled: false,
+    issuer_url: '',
+    client_id: '',
+    client_secret: '',
+    redirect_uri: '',
+    scope: 'openid email profile',
+    role_claim_path: 'roles',
+    default_role: 'employee',
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [hasClientSecret, setHasClientSecret] = useState(false);
+
+  useEffect(() => {
+    fetchSettings();
+  }, []);
+
+  const fetchSettings = async () => {
+    try {
+      const response = await fetch('/api/admin/oidc-settings', {
+        headers: getAuthHeaders()
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setSettings({
+          enabled: data.enabled === 1,
+          issuer_url: data.issuer_url || '',
+          client_id: data.client_id || '',
+          client_secret: '',
+          redirect_uri: data.redirect_uri || window.location.origin + '/auth/callback',
+          scope: data.scope || 'openid email profile',
+          role_claim_path: data.role_claim_path || 'roles',
+          default_role: data.default_role || 'employee',
+        });
+        setHasClientSecret(data.has_client_secret);
+      }
+    } catch (err) {
+      toast({ title: "Error", description: 'Failed to load OIDC settings', variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (name, value) => {
+    setSettings({
+      ...settings,
+      [name]: value
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+
+    try {
+      const response = await fetch('/api/admin/oidc-settings', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders()
+        },
+        body: JSON.stringify(settings),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save settings');
+      }
+
+      toast({ title: "Success", description: 'OIDC settings saved successfully!' });
+      setHasClientSecret(!!settings.client_secret || hasClientSecret);
+    } catch (err) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Enable Toggle */}
+      <div className="flex items-center justify-between space-x-4">
+        <div className="flex-1">
+          <Label htmlFor="oidc-enabled" className="text-base font-semibold">
+            Enable OIDC/SSO Authentication
+          </Label>
+          <p className="text-sm text-muted-foreground mt-1">
+            Allow users to sign in with an external identity provider
+          </p>
+        </div>
+        <Switch
+          id="oidc-enabled"
+          checked={settings.enabled}
+          onCheckedChange={(checked) => handleChange('enabled', checked)}
+        />
+      </div>
+
+      <Separator />
+
+      {/* Provider Configuration */}
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold">Provider Configuration</h3>
+
+        <div className="space-y-2">
+          <Label htmlFor="issuer_url">Issuer URL {settings.enabled && <span className="text-destructive">*</span>}</Label>
+          <Input
+            id="issuer_url"
+            name="issuer_url"
+            value={settings.issuer_url}
+            onChange={(e) => handleChange('issuer_url', e.target.value)}
+            required={settings.enabled}
+            disabled={!settings.enabled}
+            placeholder="https://your-domain.auth0.com"
+          />
+          <p className="text-xs text-muted-foreground">
+            The OIDC issuer URL from your identity provider
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="client_id">Client ID {settings.enabled && <span className="text-destructive">*</span>}</Label>
+          <Input
+            id="client_id"
+            name="client_id"
+            value={settings.client_id}
+            onChange={(e) => handleChange('client_id', e.target.value)}
+            required={settings.enabled}
+            disabled={!settings.enabled}
+            placeholder="your-client-id"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="client_secret">
+            Client Secret {settings.enabled && !hasClientSecret && <span className="text-destructive">*</span>}
+          </Label>
+          <Input
+            id="client_secret"
+            name="client_secret"
+            type="password"
+            value={settings.client_secret}
+            onChange={(e) => handleChange('client_secret', e.target.value)}
+            required={settings.enabled && !hasClientSecret}
+            disabled={!settings.enabled}
+            placeholder={hasClientSecret ? "••••••••••••" : "your-client-secret"}
+          />
+          {hasClientSecret && (
+            <p className="text-xs text-muted-foreground">
+              Leave blank to keep existing secret
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="redirect_uri">Redirect URI {settings.enabled && <span className="text-destructive">*</span>}</Label>
+          <Input
+            id="redirect_uri"
+            name="redirect_uri"
+            value={settings.redirect_uri}
+            onChange={(e) => handleChange('redirect_uri', e.target.value)}
+            required={settings.enabled}
+            disabled={!settings.enabled}
+            placeholder={window.location.origin + "/auth/callback"}
+          />
+          <p className="text-xs text-muted-foreground">
+            Configure this URL in your OIDC provider's allowed callback URLs
+          </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Advanced Settings */}
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold">Advanced Settings</h3>
+
+        <div className="space-y-2">
+          <Label htmlFor="scope">Scopes</Label>
+          <Input
+            id="scope"
+            name="scope"
+            value={settings.scope}
+            onChange={(e) => handleChange('scope', e.target.value)}
+            disabled={!settings.enabled}
+            placeholder="openid email profile"
+          />
+          <p className="text-xs text-muted-foreground">
+            Space-separated list of OAuth scopes
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="role_claim_path">Role Claim Path</Label>
+          <Input
+            id="role_claim_path"
+            name="role_claim_path"
+            value={settings.role_claim_path}
+            onChange={(e) => handleChange('role_claim_path', e.target.value)}
+            disabled={!settings.enabled}
+            placeholder="roles"
+          />
+          <p className="text-xs text-muted-foreground">
+            Path to the roles claim in the OIDC token (e.g., 'roles', 'groups', 'https://myapp.com/roles')
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="default_role">Default Role</Label>
+          <Select
+            value={settings.default_role}
+            onValueChange={(value) => handleChange('default_role', value)}
+            disabled={!settings.enabled}
+          >
+            <SelectTrigger id="default_role">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="employee">Employee</SelectItem>
+              <SelectItem value="manager">Manager</SelectItem>
+              <SelectItem value="admin">Admin</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Default role for new users if no role mapping matches
+          </p>
+        </div>
+      </div>
+
+      <Button
+        type="submit"
+        disabled={saving}
+        size="sm"
+      >
+        {saving ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          <>
+            <Save className="h-4 w-4 mr-2" />
+            Save OIDC Settings
+          </>
+        )}
+      </Button>
+    </form>
+  );
+};
+
+export default OIDCSettingsNew;

--- a/frontend/src/components/SecuritySettingsNew.jsx
+++ b/frontend/src/components/SecuritySettingsNew.jsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Fingerprint, Key, Loader2, AlertTriangle, Info, ExternalLink } from 'lucide-react';
-import OIDCSettings from './OIDCSettings';
+import OIDCSettingsNew from './OIDCSettingsNew';
 
 const SecuritySettingsNew = () => {
   const { getAuthHeaders } = useAuth();
@@ -216,7 +216,7 @@ const SecuritySettingsNew = () => {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <OIDCSettings />
+          <OIDCSettingsNew />
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/ui/switch.jsx
+++ b/frontend/src/components/ui/switch.jsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }


### PR DESCRIPTION
Changes:
- Created OIDCSettingsNew.jsx using shadcn/ui components
- Created Switch component (switch.jsx) for shadcn/ui
- Updated SecuritySettingsNew to use OIDCSettingsNew instead of OIDCSettings
- All fields now use consistent shadcn/ui styling (Input, Label, Select, Button)

OIDC settings now feature:
- Toggle switch for Enable/Disable (instead of Material-UI Switch)
- Properly sized input fields (not oversized Material-UI TextFields)
- Small "Save OIDC Settings" button with icon (not full-width large button)
- Consistent text sizing (text-sm, text-xs) matching rest of admin UI
- Form sections with proper spacing using shadcn/ui Separator

Fixes: Security tab now has completely consistent styling throughout, with both Passkey and OIDC sections using shadcn/ui components.