### PR TITLE
Add dark mode toggle and branding logo support

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,6 +28,28 @@
     --radius: 0.5rem;
   }
 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 70% 45%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
## Summary
- add a persistent dark mode toggle next to the profile avatar and expose it in the mobile menu
- load uploaded branding logos for authenticated screens and replace the header icon and title when present
- define dark theme CSS variables to support the toggle

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322582fcf0832191e6e646ed1f5a4a)