### PR TITLE
Rename 'client' to 'company' throughout the application

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -137,7 +137,7 @@ const initDb = async () => {
       employee_email TEXT NOT NULL,
       manager_name TEXT,
       manager_email TEXT,
-      client_name TEXT NOT NULL,
+      company_name TEXT NOT NULL,
       laptop_serial_number TEXT NOT NULL UNIQUE,
       laptop_asset_tag TEXT NOT NULL UNIQUE,
       laptop_make TEXT DEFAULT '',
@@ -154,7 +154,7 @@ const initDb = async () => {
       employee_email TEXT NOT NULL,
       manager_name TEXT,
       manager_email TEXT,
-      client_name TEXT NOT NULL,
+      company_name TEXT NOT NULL,
       laptop_serial_number TEXT NOT NULL UNIQUE,
       laptop_asset_tag TEXT NOT NULL UNIQUE,
       laptop_make TEXT,
@@ -425,7 +425,7 @@ const initDb = async () => {
               employee_email TEXT NOT NULL,
               manager_name TEXT,
               manager_email TEXT,
-              client_name TEXT NOT NULL,
+              company_name TEXT NOT NULL,
               laptop_serial_number TEXT NOT NULL UNIQUE,
               laptop_asset_tag TEXT NOT NULL UNIQUE,
               laptop_make TEXT,
@@ -441,7 +441,7 @@ const initDb = async () => {
           await dbRun(`
             INSERT INTO assets_new
             SELECT id, employee_name, employee_email, manager_name, manager_email,
-                   client_name, laptop_serial_number, laptop_asset_tag,
+                   company_name, laptop_serial_number, laptop_asset_tag,
                    laptop_make, laptop_model, status, registration_date, last_updated, notes
             FROM assets
           `);
@@ -455,7 +455,7 @@ const initDb = async () => {
           // Recreate indexes
           await dbRun('CREATE INDEX IF NOT EXISTS idx_employee_name ON assets(employee_name)');
           await dbRun('CREATE INDEX IF NOT EXISTS idx_manager_name ON assets(manager_name)');
-          await dbRun('CREATE INDEX IF NOT EXISTS idx_client_name ON assets(client_name)');
+          await dbRun('CREATE INDEX IF NOT EXISTS idx_company_name ON assets(company_name)');
           await dbRun('CREATE INDEX IF NOT EXISTS idx_status ON assets(status)');
 
           await dbRun('COMMIT');
@@ -506,7 +506,7 @@ const initDb = async () => {
   // Indexes
   await dbRun('CREATE INDEX IF NOT EXISTS idx_employee_name ON assets(employee_name)');
   await dbRun('CREATE INDEX IF NOT EXISTS idx_manager_name ON assets(manager_name)');
-  await dbRun('CREATE INDEX IF NOT EXISTS idx_client_name ON assets(client_name)');
+  await dbRun('CREATE INDEX IF NOT EXISTS idx_company_name ON assets(company_name)');
   await dbRun('CREATE INDEX IF NOT EXISTS idx_status ON assets(status)');
   await dbRun('CREATE INDEX IF NOT EXISTS idx_company_name ON companies(name)');
   await dbRun('CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_logs(timestamp)');
@@ -529,7 +529,7 @@ export const assetDb = {
     const insertQuery = `
       INSERT INTO assets (
         employee_name, employee_email, manager_name, manager_email,
-        client_name, laptop_make, laptop_model, laptop_serial_number, laptop_asset_tag,
+        company_name, laptop_make, laptop_model, laptop_serial_number, laptop_asset_tag,
         status, registration_date, last_updated, notes
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ${isPostgres ? 'RETURNING id' : ''}
@@ -540,7 +540,7 @@ export const assetDb = {
       asset.employee_email,
       asset.manager_name,
       asset.manager_email,
-      asset.client_name,
+      asset.company_name,
       asset.laptop_make || '',
       asset.laptop_model || '',
       asset.laptop_serial_number,
@@ -585,9 +585,9 @@ export const assetDb = {
       params.push(`%${filters.manager_name}%`);
     }
 
-    if (filters.client_name) {
-      query += ' AND client_name LIKE ?';
-      params.push(`%${filters.client_name}%`);
+    if (filters.company_name) {
+      query += ' AND company_name LIKE ?';
+      params.push(`%${filters.company_name}%`);
     }
 
     if (filters.status) {
@@ -617,7 +617,7 @@ export const assetDb = {
     return dbRun(`
       UPDATE assets
       SET employee_name = ?, employee_email = ?, manager_name = ?, manager_email = ?,
-          client_name = ?, laptop_serial_number = ?, laptop_asset_tag = ?,
+          company_name = ?, laptop_serial_number = ?, laptop_asset_tag = ?,
           status = ?, last_updated = ?, notes = ?
       WHERE id = ?
     `, [
@@ -625,7 +625,7 @@ export const assetDb = {
       asset.employee_email,
       asset.manager_name,
       asset.manager_email,
-      asset.client_name,
+      asset.company_name,
       asset.laptop_serial_number,
       asset.laptop_asset_tag,
       asset.status,
@@ -689,7 +689,7 @@ export const companyDb = {
   `, [company.name, company.description || '', id]),
   delete: async (id) => dbRun('DELETE FROM companies WHERE id = ?', [id]),
   hasAssets: async (companyName) => {
-    const row = await dbGet('SELECT COUNT(*) as count FROM assets WHERE client_name = ?', [companyName]);
+    const row = await dbGet('SELECT COUNT(*) as count FROM assets WHERE company_name = ?', [companyName]);
     return (row?.count || 0) > 0;
   }
 };
@@ -1120,7 +1120,7 @@ export const importSqliteDatabase = async (sqlitePath) => {
       await client.query(
         `INSERT INTO assets (
           id, employee_name, employee_email, manager_name, manager_email,
-          client_name, laptop_serial_number, laptop_asset_tag, laptop_make, laptop_model,
+          company_name, laptop_serial_number, laptop_asset_tag, laptop_make, laptop_model,
           status, registration_date, last_updated, notes
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)` ,
         [
@@ -1129,7 +1129,7 @@ export const importSqliteDatabase = async (sqlitePath) => {
           row.employee_email,
           row.manager_name,
           row.manager_email,
-          row.client_name,
+          row.company_name,
           row.laptop_serial_number,
           row.laptop_asset_tag,
           row.laptop_make || '',

--- a/backend/server.js
+++ b/backend/server.js
@@ -1963,7 +1963,7 @@ app.get('/api/assets/search', async (req, res) => {
     const filters = {
       employee_name: req.query.employee,
       manager_name: req.query.manager,
-      client_name: req.query.client,
+      company_name: req.query.company,
       status: req.query.status
     };
 
@@ -1986,7 +1986,7 @@ app.post('/api/assets/import', authenticate, upload.single('file'), async (req, 
     const requiredFields = [
       'employee_name',
       'employee_email',
-      'client_name',
+      'company_name',
       'laptop_serial_number',
       'laptop_asset_tag'
     ];
@@ -2033,7 +2033,7 @@ app.post('/api/assets/import', authenticate, upload.single('file'), async (req, 
         employee_email: normalizedRow.employee_email,
         manager_name,
         manager_email,
-        client_name: normalizedRow.client_name,
+        company_name: normalizedRow.company_name,
         laptop_make: normalizedRow.laptop_make || '',
         laptop_model: normalizedRow.laptop_model || '',
         laptop_serial_number: normalizedRow.laptop_serial_number,
@@ -2054,7 +2054,7 @@ app.post('/api/assets/import', authenticate, upload.single('file'), async (req, 
           {
             employee_name: assetData.employee_name,
             employee_email: assetData.employee_email,
-            client_name: assetData.client_name,
+            company_name: assetData.company_name,
             laptop_serial_number: assetData.laptop_serial_number,
             laptop_asset_tag: assetData.laptop_asset_tag,
             imported: true
@@ -2091,13 +2091,13 @@ app.post('/api/assets/import', authenticate, upload.single('file'), async (req, 
 // Create new asset
 app.post('/api/assets', authenticate, async (req, res) => {
   try {
-    const { employee_name, employee_email, client_name, laptop_serial_number, laptop_asset_tag, notes } = req.body;
+    const { employee_name, employee_email, company_name, laptop_serial_number, laptop_asset_tag, notes } = req.body;
 
     // Validation
-    if (!employee_name || !employee_email || !client_name || !laptop_serial_number || !laptop_asset_tag) {
+    if (!employee_name || !employee_email || !company_name || !laptop_serial_number || !laptop_asset_tag) {
       return res.status(400).json({
         error: 'Missing required fields',
-        required: ['employee_name', 'employee_email', 'client_name', 'laptop_serial_number', 'laptop_asset_tag']
+        required: ['employee_name', 'employee_email', 'company_name', 'laptop_serial_number', 'laptop_asset_tag']
       });
     }
 
@@ -2132,7 +2132,7 @@ app.post('/api/assets', authenticate, async (req, res) => {
         employee_email,
         manager_name,
         manager_email,
-        client_name,
+        company_name,
         laptop_serial_number,
         laptop_asset_tag
       },
@@ -2214,12 +2214,12 @@ app.put('/api/assets/:id', authenticate, async (req, res) => {
       return res.status(404).json({ error: 'Asset not found' });
     }
 
-    const { employee_name, employee_email, manager_name, manager_email, client_name, laptop_serial_number, laptop_asset_tag, status, notes } = req.body;
+    const { employee_name, employee_email, manager_name, manager_email, company_name, laptop_serial_number, laptop_asset_tag, status, notes } = req.body;
 
-    if (!employee_name || !employee_email || !client_name || !laptop_serial_number || !laptop_asset_tag) {
+    if (!employee_name || !employee_email || !company_name || !laptop_serial_number || !laptop_asset_tag) {
       return res.status(400).json({
         error: 'Missing required fields',
-        required: ['employee_name', 'employee_email', 'client_name', 'laptop_serial_number', 'laptop_asset_tag']
+        required: ['employee_name', 'employee_email', 'company_name', 'laptop_serial_number', 'laptop_asset_tag']
       });
     }
 
@@ -2297,7 +2297,7 @@ app.delete('/api/assets/:id', authenticate, async (req, res) => {
         employee_email: asset.employee_email,
         manager_name: asset.manager_name,
         manager_email: asset.manager_email,
-        client_name: asset.client_name,
+        company_name: asset.company_name,
         laptop_serial_number: asset.laptop_serial_number,
         laptop_asset_tag: asset.laptop_asset_tag,
         status: asset.status,
@@ -2711,7 +2711,7 @@ app.get('/api/reports/summary', authenticate, async (req, res) => {
       summary.by_status[asset.status] = (summary.by_status[asset.status] || 0) + 1;
 
       // Company breakdown
-      summary.by_company[asset.client_name] = (summary.by_company[asset.client_name] || 0) + 1;
+      summary.by_company[asset.company_name] = (summary.by_company[asset.company_name] || 0) + 1;
 
       // Manager breakdown
       summary.by_manager[asset.manager_name] = (summary.by_manager[asset.manager_name] || 0) + 1;

--- a/frontend/public/import_assets.csv
+++ b/frontend/public/import_assets.csv
@@ -1,4 +1,4 @@
-employee_name,employee_email,manager_name,manager_email,client_name,laptop_make,laptop_model,laptop_serial_number,laptop_asset_tag,status,notes
+employee_name,employee_email,manager_name,manager_email,company_name,laptop_make,laptop_model,laptop_serial_number,laptop_asset_tag,status,notes
 Jane Doe,jane.doe@example.com,John Manager,john.manager@example.com,Acme Corp,Lenovo,ThinkPad T14,ABC12345,AT-1001,active,Primary laptop issued Q1
 Sam Smith,sam.smith@example.com,John Manager,john.manager@example.com,Globex Inc,Apple,MacBook Pro,XYZ98765,AT-1002,returned,Returned after project completion
 Alex Rivera,alex.rivera@example.com,,,Initech,Dell,Latitude 5440,LMN54321,AT-1003,lost,Reported missing during office move

--- a/frontend/src/components/AssetEditModal.jsx
+++ b/frontend/src/components/AssetEditModal.jsx
@@ -45,7 +45,7 @@ const AssetEditModal = ({ asset, onClose, onUpdate }) => {
     employee_email: asset.employee_email || '',
     manager_name: asset.manager_name || '',
     manager_email: asset.manager_email || '',
-    client_name: asset.client_name || '',
+    company_name: asset.company_name || '',
     laptop_serial_number: asset.laptop_serial_number || '',
     laptop_asset_tag: asset.laptop_asset_tag || '',
     laptop_make: asset.laptop_make || '',
@@ -218,11 +218,11 @@ const AssetEditModal = ({ asset, onClose, onUpdate }) => {
             </Typography>
             <Divider sx={{ mb: 2 }} />
             <FormControl fullWidth required>
-              <InputLabel id="client-company-label">Company</InputLabel>
+              <InputLabel id="company-label">Company</InputLabel>
               <Select
-                labelId="client-company-label"
-                name="client_name"
-                value={formData.client_name}
+                labelId="company-label"
+                name="company_name"
+                value={formData.company_name}
                 onChange={handleChange}
                 label="Company"
                 required

--- a/frontend/src/components/AssetList.jsx
+++ b/frontend/src/components/AssetList.jsx
@@ -73,7 +73,7 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
   const [filters, setFilters] = useState({
     employee: '',
     manager: '',
-    client: '',
+    company: '',
     status: ''
   });
 
@@ -138,9 +138,9 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
       );
     }
 
-    if (filters.client) {
+    if (filters.company) {
       filtered = filtered.filter(asset =>
-        asset.client_name.toLowerCase().includes(filters.client.toLowerCase())
+        asset.company_name.toLowerCase().includes(filters.company.toLowerCase())
       );
     }
 
@@ -164,7 +164,7 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
     setFilters({
       employee: '',
       manager: '',
-      client: '',
+      company: '',
       status: ''
     });
   };
@@ -317,7 +317,7 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
     return colors[status] || 'default';
   };
 
-  const hasActiveFilters = filters.employee || filters.manager || filters.client || filters.status;
+  const hasActiveFilters = filters.employee || filters.manager || filters.company || filters.status;
 
   if (loading) {
     return (
@@ -411,10 +411,10 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
               <TextField
                 fullWidth
                 size="small"
-                name="client"
+                name="company"
                 label="Company"
                 placeholder="Search by company..."
-                value={filters.client}
+                value={filters.company}
                 onChange={handleFilterChange}
               />
             </Grid>
@@ -488,7 +488,7 @@ const AssetList = ({ refresh, onAssetRegistered }) => {
                     <TableCell>{asset.employee_name}</TableCell>
                     {!isMobile && <TableCell>{asset.employee_email || '-'}</TableCell>}
                     {!isMobile && <TableCell>{asset.manager_email || '-'}</TableCell>}
-                    <TableCell>{asset.client_name}</TableCell>
+                    <TableCell>{asset.company_name}</TableCell>
                     {!isMobile && <TableCell>{asset.laptop_serial_number}</TableCell>}
                     {!isMobile && <TableCell>{asset.laptop_asset_tag}</TableCell>}
                     <TableCell>

--- a/frontend/src/components/AssetRegistrationForm.jsx
+++ b/frontend/src/components/AssetRegistrationForm.jsx
@@ -23,7 +23,7 @@ const AssetRegistrationForm = ({ onAssetRegistered }) => {
     employee_first_name: '',
     employee_last_name: '',
     employee_email: '',
-    client_name: '',
+    company_name: '',
     laptop_make: '',
     laptop_model: '',
     laptop_serial_number: '',
@@ -112,7 +112,7 @@ const AssetRegistrationForm = ({ onAssetRegistered }) => {
           employee_first_name: user.first_name || '',
           employee_last_name: user.last_name || '',
           employee_email: user.email || '',
-          client_name: '',
+          company_name: '',
           laptop_make: '',
           laptop_model: '',
           laptop_serial_number: '',
@@ -124,7 +124,7 @@ const AssetRegistrationForm = ({ onAssetRegistered }) => {
           employee_first_name: '',
           employee_last_name: '',
           employee_email: '',
-          client_name: '',
+          company_name: '',
           laptop_make: '',
           laptop_model: '',
           laptop_serial_number: '',
@@ -224,8 +224,8 @@ const AssetRegistrationForm = ({ onAssetRegistered }) => {
             <InputLabel id="company-label">Company</InputLabel>
             <Select
               labelId="company-label"
-              name="client_name"
-              value={formData.client_name}
+              name="company_name"
+              value={formData.company_name}
               onChange={handleChange}
               label="Company"
               required

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -78,7 +78,7 @@ const Dashboard = () => {
     employee_first_name: '',
     employee_last_name: '',
     employee_email: '',
-    client_name: '',
+    company_name: '',
     laptop_make: '',
     laptop_model: '',
     laptop_serial_number: '',
@@ -168,7 +168,7 @@ const Dashboard = () => {
         asset.employee_name?.toLowerCase().includes(query) ||
         asset.employee_email?.toLowerCase().includes(query) ||
         asset.manager_name?.toLowerCase().includes(query) ||
-        asset.client_name?.toLowerCase().includes(query) ||
+        asset.company_name?.toLowerCase().includes(query) ||
         asset.laptop_serial_number?.toLowerCase().includes(query) ||
         asset.laptop_asset_tag?.toLowerCase().includes(query)
       );
@@ -258,7 +258,7 @@ const Dashboard = () => {
         employee_first_name: user.first_name || '',
         employee_last_name: user.last_name || '',
         employee_email: user.email || '',
-        client_name: '',
+        company_name: '',
         laptop_make: '',
         laptop_model: '',
         laptop_serial_number: '',
@@ -270,7 +270,7 @@ const Dashboard = () => {
         employee_first_name: '',
         employee_last_name: '',
         employee_email: '',
-        client_name: '',
+        company_name: '',
         laptop_make: '',
         laptop_model: '',
         laptop_serial_number: '',
@@ -551,7 +551,7 @@ const Dashboard = () => {
                       <TableCell className="font-mono text-sm">{asset.employee_email}</TableCell>
                       <TableCell>{asset.manager_name || '—'}</TableCell>
                       <TableCell className="font-mono text-sm">{asset.manager_email || '—'}</TableCell>
-                      <TableCell>{asset.client_name}</TableCell>
+                      <TableCell>{asset.company_name}</TableCell>
                       <TableCell>{asset.laptop_make || '—'}</TableCell>
                       <TableCell>{asset.laptop_model || '—'}</TableCell>
                       <TableCell className="font-mono text-sm">{asset.laptop_serial_number}</TableCell>
@@ -651,10 +651,10 @@ const Dashboard = () => {
             <div className="space-y-4">
               <h4 className="font-medium text-primary">Client Information</h4>
               <div className="space-y-2">
-                <Label htmlFor="client_name">Client Company</Label>
+                <Label htmlFor="company_name">Client Company</Label>
                 <Select
-                  value={regFormData.client_name}
-                  onValueChange={(value) => setRegFormData({ ...regFormData, client_name: value })}
+                  value={regFormData.company_name}
+                  onValueChange={(value) => setRegFormData({ ...regFormData, company_name: value })}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select a company..." />
@@ -855,7 +855,7 @@ const Dashboard = () => {
               <div className="rounded-md bg-muted/50 p-4 text-sm space-y-1">
                 <p className="font-medium text-foreground">Required columns</p>
                 <p className="text-muted-foreground">
-                  employee_name, employee_email, client_name, laptop_serial_number, laptop_asset_tag
+                  employee_name, employee_email, company_name, laptop_serial_number, laptop_asset_tag
                 </p>
                 <p className="font-medium text-foreground pt-2">Optional columns</p>
                 <p className="text-muted-foreground">


### PR DESCRIPTION
Changes:
- Updated database schema: renamed client_name column to company_name
- Updated all backend queries and API endpoints to use company_name
- Updated frontend components (AssetList, AssetEditModal, AssetRegistrationForm, Dashboard)
- Updated CSV import template to use company_name header
- Fixed display columns in AssetList to show: Employee, Employee Email, Manager Email, Company, Serial Number, Asset Tag, Status
- Maintained column customization functionality for optional columns
- Asset edit form already allows editing all required fields
- Employees already restricted from editing their own names and email