### PR TITLE
Fix OIDC SSO sign-in by passing expectedSubject to fetchUserInfo

### DIFF
--- a/backend/oidc.js
+++ b/backend/oidc.js
@@ -140,7 +140,15 @@ async function getUserInfo(tokens) {
     throw new Error('OIDC client not initialized');
   }
 
-  const userinfo = await client.fetchUserInfo(config, tokens.access_token);
+  // Extract the subject from the ID token claims for validation
+  const claims = tokens.claims();
+  const sub = claims?.sub;
+
+  if (!sub) {
+    throw new Error('No subject (sub) claim found in ID token');
+  }
+
+  const userinfo = await client.fetchUserInfo(config, tokens.access_token, sub);
   return userinfo;
 }
 


### PR DESCRIPTION
The openid-client library's fetchUserInfo function requires the subject (sub) claim from the ID token as the third parameter to validate the userinfo response. Without this, the oauth4webapi library throws "expectedSubject must be a string" error.