### PR TITLE
Add adjustable pagination controls to tables

### DIFF
--- a/frontend/src/components/TablePaginationControls.jsx
+++ b/frontend/src/components/TablePaginationControls.jsx
@@ -1,0 +1,88 @@
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+const TablePaginationControls = ({
+  page,
+  pageSize,
+  totalItems,
+  onPageChange,
+  onPageSizeChange,
+}) => {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize) || 1);
+  const startItem = totalItems === 0 ? 0 : (page - 1) * pageSize + 1;
+  const endItem = Math.min(totalItems, page * pageSize);
+
+  const handlePageChange = (newPage) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    onPageChange(newPage);
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border bg-muted/40 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-sm text-muted-foreground">
+        Showing{' '}
+        <span className="font-medium text-foreground">{startItem}</span>
+        {totalItems > 0 && (
+          <>
+            {' '}-{' '}
+            <span className="font-medium text-foreground">{endItem}</span>
+          </>
+        )}{' '}
+        of <span className="font-medium text-foreground">{totalItems}</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Rows per page</span>
+          <Select value={String(pageSize)} onValueChange={(value) => onPageSizeChange(Number(value))}>
+            <SelectTrigger className="w-[110px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <SelectItem key={size} value={String(size)}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => handlePageChange(page - 1)}
+            disabled={page <= 1}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <div className="min-w-[80px] text-center text-sm font-medium text-foreground">
+            Page {page} of {totalPages}
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => handlePageChange(page + 1)}
+            disabled={page >= totalPages || totalItems === 0}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TablePaginationControls;


### PR DESCRIPTION
## Summary
- add shared table pagination control with page size selector and navigation buttons
- integrate paginated views for assets, companies, audit logs, and admin users with consistent row count controls
- ensure selection logic respects current page and update totals accordingly

## Testing
- npm test -- --runInBand *(fails: npm not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693338d9055c832181edae935a2596db)