### PR TITLE
Add admin controls for passkeys and SSO button

### DIFF
--- a/frontend/src/components/OIDCCallback.jsx
+++ b/frontend/src/components/OIDCCallback.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Box, CircularProgress, Typography, Alert, Card, CardContent } from '@mui/material';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader2, AlertCircle, ShieldCheck } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 const OIDCCallback = () => {
@@ -10,9 +12,25 @@ const OIDCCallback = () => {
   const [error, setError] = useState(null);
   const [processing, setProcessing] = useState(true);
   const processedRef = useRef(false);
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
 
   useEffect(() => {
-    // Prevent multiple calls (React Strict Mode, re-renders, etc.)
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme && storedTheme !== theme) {
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
+
+  useEffect(() => {
     if (processedRef.current) {
       return;
     }
@@ -33,7 +51,6 @@ const OIDCCallback = () => {
           throw new Error('Missing authorization code or state');
         }
 
-        // Call backend to complete OIDC flow
         const response = await fetch(`/api/auth/oidc/callback?code=${code}&state=${state}`);
         const data = await response.json();
 
@@ -41,10 +58,8 @@ const OIDCCallback = () => {
           throw new Error(data.error || 'OIDC authentication failed');
         }
 
-        // Store auth data
         setAuthData(data.token, data.user);
 
-        // Redirect to home
         setTimeout(() => navigate('/'), 500);
       } catch (err) {
         console.error('OIDC callback error:', err);
@@ -57,41 +72,36 @@ const OIDCCallback = () => {
   }, [searchParams, navigate, setAuthData]);
 
   return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        bgcolor: 'background.default',
-        p: 2,
-      }}
-    >
-      <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4, textAlign: 'center' }}>
-          {processing ? (
-            <>
-              <CircularProgress size={60} sx={{ mb: 3 }} />
-              <Typography variant="h6" gutterBottom>
-                Completing sign in...
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Please wait while we verify your authentication
-              </Typography>
-            </>
-          ) : (
-            <>
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {error}
-              </Alert>
-              <Typography variant="body2" color="text.secondary">
-                <a href="/login">Return to login</a>
-              </Typography>
-            </>
-          )}
-        </CardContent>
-      </Card>
-    </Box>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 p-4">
+      <div className="w-full max-w-md">
+        <Card className="shadow-lg">
+          <CardHeader className="text-center space-y-2">
+            <div className="mx-auto h-12 w-12 rounded-full bg-primary/10 text-primary flex items-center justify-center">
+              {processing ? <Loader2 className="h-6 w-6 animate-spin" /> : <ShieldCheck className="h-6 w-6" />}
+            </div>
+            <CardTitle>Completing sign in...</CardTitle>
+            <CardDescription>Hang tight while we verify your authentication details.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-center">
+            {processing ? (
+              <div className="space-y-3 text-muted-foreground">
+                <p className="text-sm">This will only take a moment.</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex items-center justify-center gap-2 text-destructive">
+                  <AlertCircle className="h-5 w-5" />
+                  <span className="font-medium">{error}</span>
+                </div>
+                <Button variant="outline" onClick={() => navigate('/login')}>
+                  Return to login
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/OIDCSettingsNew.jsx
+++ b/frontend/src/components/OIDCSettingsNew.jsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -27,6 +28,9 @@ const OIDCSettingsNew = () => {
     scope: 'openid email profile',
     role_claim_path: 'roles',
     default_role: 'employee',
+    sso_button_text: 'Sign In with SSO',
+    sso_button_help_text: '',
+    sso_button_variant: 'outline',
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -53,6 +57,9 @@ const OIDCSettingsNew = () => {
           scope: data.scope || 'openid email profile',
           role_claim_path: data.role_claim_path || 'roles',
           default_role: data.default_role || 'employee',
+          sso_button_text: data.sso_button_text || 'Sign In with SSO',
+          sso_button_help_text: data.sso_button_help_text || '',
+          sso_button_variant: data.sso_button_variant || 'outline',
         });
         setHasClientSecret(data.has_client_secret);
       }
@@ -254,6 +261,57 @@ const OIDCSettingsNew = () => {
           <p className="text-xs text-muted-foreground">
             Default role for new users if no role mapping matches
           </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold">Sign in button customization</h3>
+
+        <div className="space-y-2">
+          <Label htmlFor="sso_button_text">Button label</Label>
+          <Input
+            id="sso_button_text"
+            name="sso_button_text"
+            value={settings.sso_button_text}
+            onChange={(e) => handleChange('sso_button_text', e.target.value)}
+            disabled={!settings.enabled}
+            placeholder="Sign In with SSO"
+          />
+          <p className="text-xs text-muted-foreground">Set the text users see on the sign-in button.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sso_button_help_text">Helper text (optional)</Label>
+          <Textarea
+            id="sso_button_help_text"
+            name="sso_button_help_text"
+            value={settings.sso_button_help_text}
+            onChange={(e) => handleChange('sso_button_help_text', e.target.value)}
+            disabled={!settings.enabled}
+            placeholder="Use your company identity provider."
+          />
+          <p className="text-xs text-muted-foreground">Appears below the button on the sign-in page.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sso_button_variant">Button style</Label>
+          <Select
+            value={settings.sso_button_variant}
+            onValueChange={(value) => handleChange('sso_button_variant', value)}
+            disabled={!settings.enabled}
+          >
+            <SelectTrigger id="sso_button_variant">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">Primary</SelectItem>
+              <SelectItem value="secondary">Muted</SelectItem>
+              <SelectItem value="outline">Outline</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">Match your branding by selecting a button variant.</p>
         </div>
       </div>
 

--- a/frontend/src/components/SecuritySettingsNew.jsx
+++ b/frontend/src/components/SecuritySettingsNew.jsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Switch } from '@/components/ui/switch';
 import { Fingerprint, Key, Loader2, AlertTriangle, Info, ExternalLink } from 'lucide-react';
 import OIDCSettingsNew from './OIDCSettingsNew';
 
@@ -17,6 +18,7 @@ const SecuritySettingsNew = () => {
     rp_id: 'localhost',
     rp_name: 'KARS - KeyData Asset Registration System',
     origin: 'http://localhost:5173',
+    enabled: true,
     managed_by_env: false
   });
   const [loading, setLoading] = useState(false);
@@ -52,7 +54,8 @@ const SecuritySettingsNew = () => {
         body: JSON.stringify({
           rp_id: passkeySettings.rp_id,
           rp_name: passkeySettings.rp_name,
-          origin: passkeySettings.origin
+          origin: passkeySettings.origin,
+          enabled: passkeySettings.enabled
         })
       });
       const data = await response.json();
@@ -79,11 +82,32 @@ const SecuritySettingsNew = () => {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3 bg-muted/50">
+            <div>
+              <p className="font-medium">Passkey sign-in</p>
+              <p className="text-sm text-muted-foreground">Toggle to allow users to register and sign in with passkeys.</p>
+            </div>
+            <Switch
+              checked={passkeySettings.enabled}
+              onCheckedChange={(checked) => setPasskeySettings({ ...passkeySettings, enabled: checked })}
+              disabled={passkeySettings.managed_by_env || loading}
+            />
+          </div>
+
+          {!passkeySettings.enabled && (
+            <Alert variant="warning">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertDescription className="text-sm">
+                Passkey registration and sign-in are currently disabled. Users will not see passkey options on the login page while this is off.
+              </AlertDescription>
+            </Alert>
+          )}
+
           {passkeySettings.managed_by_env && (
             <Alert variant="warning">
               <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
-                Passkey settings are currently managed by environment variables. To use database configuration, remove PASSKEY_RP_ID, PASSKEY_RP_NAME, and PASSKEY_ORIGIN from your environment variables and restart the backend.
+                Passkey settings are currently managed by environment variables. To use database configuration, remove PASSKEY_RP_ID, PASSKEY_RP_NAME, PASSKEY_ORIGIN, and PASSKEY_ENABLED from your environment variables and restart the backend.
               </AlertDescription>
             </Alert>
           )}


### PR DESCRIPTION
## Summary
- add database support and UI controls to enable or disable passkey sign-in and expose the setting to the login page
- allow administrators to customize SSO button copy and styling, and surface those settings on the sign-in experience
- update the OIDC callback screen to match the current UI and honor the selected light/dark theme

## Testing
- Not run (npm is not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334166aee08321ac2c4009f43c9681)