### PR TITLE
Allow overriding GHCR auth token for deploy workflow

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
   IMAGE_NAME_FRONTEND: ${{ github.repository }}/frontend
   IMAGE_NAME_BACKEND: ${{ github.repository }}/backend
 
@@ -29,8 +31,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Extract metadata for frontend
         id: meta-frontend


### PR DESCRIPTION
## Summary
- allow the deploy workflow to authenticate to GHCR with a dedicated `GHCR_TOKEN` if provided
- default to repository owner credentials for image pushes to improve reliability

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334be8bc288321b891e3f32e5b2f84)