### PR TITLE
Restrict team view to managed employees and add asset view

### DIFF
--- a/frontend/src/AppNew.jsx
+++ b/frontend/src/AppNew.jsx
@@ -321,7 +321,9 @@ function AppNew() {
         <Routes>
           <Route path="/" element={<Navigate to="/assets" replace />} />
           <Route path="/assets" element={<Dashboard />} />
-          <Route path="/team" element={<TeamManagement />} />
+          {(user?.role === 'admin' || user?.role === 'manager') && (
+            <Route path="/team" element={<TeamManagement />} />
+          )}
           {user?.role === 'admin' && (
             <Route path="/companies" element={<CompanyManagementNew />} />
           )}


### PR DESCRIPTION
## Summary
- limit access to the Team route to admins and managers only
- scope team insights to the signed-in manager’s direct reports and their assets with clearer guidance
- add an asset-centric view that maps devices to companies, owners, and managers for easier auditing

## Testing
- npm test -- --runInBand *(fails: npm command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933871eefb48321bb9bc41379bd9aca)