### PR TITLE
Enhance selected state visibility in tables

### DIFF
--- a/frontend/src/components/CompanyManagementNew.jsx
+++ b/frontend/src/components/CompanyManagementNew.jsx
@@ -295,7 +295,7 @@ const CompanyManagementNew = () => {
                     key={company.id}
                     className={cn(
                       "border rounded-lg p-4 flex gap-3",
-                      selectedIds.has(company.id) && "bg-primary/5 border-primary/30"
+                      selectedIds.has(company.id) && "bg-primary/5 border-primary/50 shadow-[0_0_0_1px_hsl(var(--primary))]"
                     )}
                   >
                     <Checkbox
@@ -341,7 +341,7 @@ const CompanyManagementNew = () => {
                       <TableRow
                         key={company.id}
                         data-state={selectedIds.has(company.id) ? "selected" : undefined}
-                        className={cn(selectedIds.has(company.id) && "bg-primary/5")}
+                        className={cn(selectedIds.has(company.id) && "bg-primary/5 border-primary/40")}
                       >
                         <TableCell>
                           <Checkbox

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -964,7 +964,7 @@ const Dashboard = () => {
                   key={asset.id}
                   className={cn(
                     "border rounded-lg p-4 transition-colors",
-                    selectedIds.has(asset.id) && "bg-primary/5 border-primary/30"
+                    selectedIds.has(asset.id) && "bg-primary/5 border-primary/50 shadow-[0_0_0_1px_hsl(var(--primary))]"
                   )}
                 >
                   <div className="flex items-start gap-3">
@@ -1054,13 +1054,13 @@ const Dashboard = () => {
                 </TableHeader>
                 <TableBody>
                   {paginatedAssets.map((asset) => (
-                    <TableRow
-                      key={asset.id}
-                      data-state={selectedIds.has(asset.id) ? "selected" : undefined}
-                      className={cn(
-                        selectedIds.has(asset.id) && "bg-primary/5"
-                      )}
-                    >
+                  <TableRow
+                    key={asset.id}
+                    data-state={selectedIds.has(asset.id) ? "selected" : undefined}
+                    className={cn(
+                      selectedIds.has(asset.id) && "bg-primary/5 border-primary/40"
+                    )}
+                  >
                       <TableCell>
                         <Checkbox
                           checked={selectedIds.has(asset.id)}

--- a/frontend/src/components/ui/table.jsx
+++ b/frontend/src/components/ui/table.jsx
@@ -39,7 +39,7 @@ const TableRow = React.forwardRef(({ className, ...props }, ref) => (
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-primary/10 data-[state=selected]:border-primary/40 data-[state=selected]:shadow-[inset_4px_0_0_hsl(var(--primary))]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- highlight selected table rows with a primary accent border and inset highlight
- make selected states in assets and companies mobile cards more noticeable
- align selected styling across list and table views for better UX clarity

## Testing
- npm run build *(fails: npm command unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bb28d31c8321a90a999940a47fd8)