### PR TITLE
Fix actions cell JSX in admin settings table

### DIFF
--- a/frontend/src/components/AdminSettingsNew.jsx
+++ b/frontend/src/components/AdminSettingsNew.jsx
@@ -527,16 +527,22 @@ const AdminSettingsNew = () => {
                               </div>
                             </TableCell>
                             <TableCell className="hidden lg:table-cell">{formatDate(u.last_login)}</TableCell>
-                            <TableCell className="text-right">
-                              <div className="flex justify-end gap-1">
-                                <Button variant="ghost" size="icon" onClick={() => openEditDialog(u)}>
-                                  <Edit className="h-4 w-4" />
-                                </Button>
-                                <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive" onClick={() => setDeleteDialog({ open: true, user: u })} disabled={u.id === user.id}>
-                                  <Trash2 className="h-4 w-4" />
-                                </Button>
-                              </div>
-                            </TableCell>
+                              <TableCell className="text-right">
+                                <div className="flex justify-end gap-1">
+                                  <Button variant="ghost" size="icon" onClick={() => openEditDialog(u)}>
+                                    <Edit className="h-4 w-4" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-destructive hover:text-destructive"
+                                    onClick={() => setDeleteDialog({ open: true, user: u })}
+                                    disabled={u.id === user.id}
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </div>
+                              </TableCell>
                           </TableRow>
                         ))}
                       </TableBody>


### PR DESCRIPTION
## Summary
- align the admin user table action buttons to valid JSX structure for edit/delete actions

## Testing
- not run (npm unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933cf63658c83218b546c8486bd16f2)