### PR TITLE
Fix duplicate pagination on admin settings

### DIFF
--- a/frontend/src/components/AdminSettingsNew.jsx
+++ b/frontend/src/components/AdminSettingsNew.jsx
@@ -549,16 +549,6 @@ const AdminSettingsNew = () => {
                       </TableBody>
                     </Table>
 
-                    {filteredUsers.length > 0 && (
-                      <TablePaginationControls
-                        className="mt-4"
-                        page={usersPage}
-                        pageSize={usersPageSize}
-                        totalItems={filteredUsers.length}
-                        onPageChange={setUsersPage}
-                        onPageSizeChange={setUsersPageSize}
-                      />
-                    )}
                   </div>
                     {filteredUsers.length > 0 ? (
                       <TablePaginationControls


### PR DESCRIPTION
## Summary
- remove redundant pagination controls on the admin users table to avoid duplicate display

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933d66c0f948321bb19ef4a8134f81f)