### PR TITLE
fix: Consistent Admin Settings UI across all tabs

### DIFF
--- a/frontend/src/components/HubSpotSettings.jsx
+++ b/frontend/src/components/HubSpotSettings.jsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Loader2, AlertTriangle, Info, CheckCircle2, XCircle, RefreshCw, ExternalLink } from 'lucide-react';
+import { Loader2, Info, CheckCircle2, XCircle, RefreshCw, ExternalLink, Save } from 'lucide-react';
 
 const HubSpotSettings = () => {
   const { getAuthHeaders } = useAuth();
@@ -114,7 +114,6 @@ const HubSpotSettings = () => {
 
       toast({ title: "Success", description: 'HubSpot settings saved successfully!' });
       setHasAccessToken(!!settings.access_token || hasAccessToken);
-      // Clear the access token field after saving
       setSettings(prev => ({ ...prev, access_token: '' }));
     } catch (err) {
       toast({ title: "Error", description: err.message, variant: "destructive" });
@@ -137,8 +136,8 @@ const HubSpotSettings = () => {
         throw new Error(data.error || 'Connection test failed');
       }
 
-      toast({ 
-        title: "Success", 
+      toast({
+        title: "Success",
         description: data.message || 'Successfully connected to HubSpot!'
       });
     } catch (err) {
@@ -162,12 +161,11 @@ const HubSpotSettings = () => {
         throw new Error(data.error || 'Sync failed');
       }
 
-      toast({ 
-        title: "Success", 
+      toast({
+        title: "Success",
         description: `Synced ${data.companiesFound} companies: ${data.companiesCreated} created, ${data.companiesUpdated} updated`
       });
 
-      // Refresh settings and history
       await fetchSettings();
       await fetchSyncHistory();
     } catch (err) {
@@ -207,13 +205,13 @@ const HubSpotSettings = () => {
   }
 
   return (
-    <div className="space-y-3">
-      <form onSubmit={handleSubmit} className="space-y-3">
-        {/* Enable Toggle */}
-        <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2 bg-muted/50">
+    <div className="space-y-4">
+      {/* HubSpot Integration - Main Container */}
+      <div className="rounded-lg border p-4">
+        <div className="flex items-center justify-between mb-4">
           <div>
-            <p className="font-medium text-sm">Enable HubSpot Integration</p>
-            <p className="text-xs text-muted-foreground">Automatically sync companies from HubSpot CRM.</p>
+            <h3 className="text-sm font-semibold">HubSpot Integration</h3>
+            <p className="text-sm text-muted-foreground">Automatically sync companies from HubSpot CRM.</p>
           </div>
           <Switch
             id="hubspot-enabled"
@@ -222,149 +220,146 @@ const HubSpotSettings = () => {
           />
         </div>
 
-        {/* Configuration Section */}
-        <div className="space-y-3 rounded-lg border p-3">
-          <h3 className="text-sm font-medium">HubSpot Configuration</h3>
-          <div className="space-y-1.5">
-            <Label htmlFor="access_token" className="text-xs">
-              Access Token {settings.enabled && !hasAccessToken && <span className="text-destructive">*</span>}
-            </Label>
-            <Input
-              id="access_token"
-              name="access_token"
-              type="password"
-              value={settings.access_token}
-              onChange={(e) => handleChange('access_token', e.target.value)}
-              required={settings.enabled && !hasAccessToken}
-              disabled={!settings.enabled}
-              placeholder={hasAccessToken ? "••••••••••••" : "pat-na1-..."}
-              className="font-mono text-sm"
-            />
-            {hasAccessToken && (
-              <p className="text-xs text-muted-foreground">
-                Leave blank to keep existing token
-              </p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Create a Private App in HubSpot with <code className="bg-muted px-1 py-0.5 rounded">crm.objects.companies.read</code> scope
-            </p>
-          </div>
-
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleTestConnection}
-              disabled={!hasAccessToken || testing || !settings.enabled}
-            >
-              {testing ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Testing...
-                </>
-              ) : (
-                <>Test Connection</>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Configuration */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Configuration</h4>
+            <div className="space-y-1.5">
+              <Label htmlFor="access_token" className="text-sm">
+                Access Token {settings.enabled && !hasAccessToken && <span className="text-destructive">*</span>}
+              </Label>
+              <Input
+                id="access_token"
+                name="access_token"
+                type="password"
+                value={settings.access_token}
+                onChange={(e) => handleChange('access_token', e.target.value)}
+                required={settings.enabled && !hasAccessToken}
+                disabled={!settings.enabled}
+                placeholder={hasAccessToken ? "••••••••••••" : "pat-na1-..."}
+                className="font-mono text-sm"
+              />
+              {hasAccessToken && (
+                <p className="text-sm text-muted-foreground">
+                  Leave blank to keep existing token
+                </p>
               )}
-            </Button>
-            <a
-              href="https://developers.hubspot.com/docs/api/private-apps"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-primary hover:underline flex items-center gap-1"
-            >
-              <Info className="h-3 w-3" />
-              HubSpot Private Apps Guide
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
-        </div>
-
-        {/* Auto-Sync Configuration */}
-        <div className="space-y-3 rounded-lg border p-3">
-          <h3 className="text-sm font-medium">Automatic Sync</h3>
-          <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2 bg-muted/50">
-            <div>
-              <p className="font-medium text-sm">Enable auto-sync</p>
-              <p className="text-xs text-muted-foreground">Automatically sync on schedule</p>
+              <p className="text-sm text-muted-foreground">
+                Create a Private App in HubSpot with <code className="bg-muted px-1 py-0.5 rounded">crm.objects.companies.read</code> scope
+              </p>
             </div>
-            <Switch
-              checked={settings.auto_sync_enabled}
-              onCheckedChange={(checked) => handleChange('auto_sync_enabled', checked)}
-              disabled={!settings.enabled}
-            />
+
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleTestConnection}
+                disabled={!hasAccessToken || testing || !settings.enabled}
+              >
+                {testing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Testing...
+                  </>
+                ) : (
+                  <>Test Connection</>
+                )}
+              </Button>
+              <a
+                href="https://developers.hubspot.com/docs/api/private-apps"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary hover:underline flex items-center gap-1"
+              >
+                <Info className="h-3 w-3" />
+                HubSpot Private Apps Guide
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="sync_interval" className="text-xs">Sync Interval</Label>
-            <Select
-              value={settings.sync_interval}
-              onValueChange={(value) => handleChange('sync_interval', value)}
-              disabled={!settings.enabled || !settings.auto_sync_enabled}
-            >
-              <SelectTrigger id="sync_interval">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="hourly">Hourly</SelectItem>
-                <SelectItem value="daily">Daily</SelectItem>
-                <SelectItem value="weekly">Weekly</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              How often to automatically sync companies from HubSpot
-            </p>
+          {/* Automatic Sync */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Automatic Sync</h4>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="auto_sync_enabled"
+                checked={settings.auto_sync_enabled}
+                onCheckedChange={(checked) => handleChange('auto_sync_enabled', checked)}
+                disabled={!settings.enabled}
+              />
+              <Label htmlFor="auto_sync_enabled" className="text-sm cursor-pointer">Enable automatic sync</Label>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sync_interval" className="text-sm">Sync Interval</Label>
+              <Select
+                value={settings.sync_interval}
+                onValueChange={(value) => handleChange('sync_interval', value)}
+                disabled={!settings.enabled || !settings.auto_sync_enabled}
+              >
+                <SelectTrigger id="sync_interval">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="hourly">Hourly</SelectItem>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-sm text-muted-foreground">
+                How often to automatically sync companies from HubSpot
+              </p>
+            </div>
+
+            {!settings.auto_sync_enabled && (
+              <Alert className="py-2">
+                <Info className="h-4 w-4" />
+                <AlertDescription className="text-sm">
+                  Automatic sync is disabled. Use the "Sync Now" button to sync manually.
+                </AlertDescription>
+              </Alert>
+            )}
           </div>
 
-          {!settings.auto_sync_enabled && (
-            <Alert className="py-2">
-              <Info className="h-4 w-4" />
-              <AlertDescription className="text-xs">
-                Note: Automatic sync is currently disabled. Use the "Sync Now" button to sync manually.
-              </AlertDescription>
-            </Alert>
-          )}
-        </div>
-
-        {/* Save Button */}
-        <Button
-          type="submit"
-          disabled={saving}
-          size="sm"
-        >
-          {saving ? (
-            <>
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            <>Save Settings</>
-          )}
-        </Button>
-      </form>
+          {/* Save Button */}
+          <Button type="submit" disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4 mr-2" />
+                Save Settings
+              </>
+            )}
+          </Button>
+        </form>
+      </div>
 
       {/* Sync Status */}
-      <div className="space-y-3 rounded-lg border p-3">
-        <h3 className="text-sm font-medium">Sync Status</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+      <div className="rounded-lg border p-4">
+        <h3 className="text-sm font-semibold mb-3">Sync Status</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Last Sync</p>
+            <p className="text-sm text-muted-foreground">Last Sync</p>
             <p className="text-sm font-medium">{formatDate(settings.last_sync)}</p>
           </div>
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Status</p>
+            <p className="text-sm text-muted-foreground">Status</p>
             <div>{getSyncStatusBadge(settings.last_sync_status)}</div>
           </div>
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Companies Synced</p>
+            <p className="text-sm text-muted-foreground">Companies Synced</p>
             <p className="text-sm font-medium">{settings.companies_synced}</p>
           </div>
         </div>
 
         <Button
           type="button"
-          variant="default"
-          size="sm"
           onClick={handleSyncNow}
           disabled={!hasAccessToken || syncing || !settings.enabled}
         >
@@ -383,10 +378,10 @@ const HubSpotSettings = () => {
       </div>
 
       {/* Sync History */}
-      <div className="space-y-3 rounded-lg border p-3">
-        <div>
-          <h3 className="text-sm font-medium">Sync History</h3>
-          <p className="text-xs text-muted-foreground">Recent synchronization results</p>
+      <div className="rounded-lg border p-4">
+        <div className="mb-3">
+          <h3 className="text-sm font-semibold">Sync History</h3>
+          <p className="text-sm text-muted-foreground">Recent synchronization results</p>
         </div>
         {loadingHistory ? (
           <div className="flex items-center justify-center py-4">
@@ -401,21 +396,21 @@ const HubSpotSettings = () => {
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/50">
-                  <TableHead className="text-xs">Started</TableHead>
-                  <TableHead className="text-xs">Status</TableHead>
-                  <TableHead className="text-xs text-right">Found</TableHead>
-                  <TableHead className="text-xs text-right">Created</TableHead>
-                  <TableHead className="text-xs text-right">Updated</TableHead>
+                  <TableHead className="text-sm">Started</TableHead>
+                  <TableHead className="text-sm">Status</TableHead>
+                  <TableHead className="text-sm text-right">Found</TableHead>
+                  <TableHead className="text-sm text-right">Created</TableHead>
+                  <TableHead className="text-sm text-right">Updated</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {syncHistory.map((sync) => (
                   <TableRow key={sync.id}>
-                    <TableCell className="text-xs">{formatDate(sync.sync_started_at)}</TableCell>
-                    <TableCell className="text-xs">{getSyncStatusBadge(sync.status)}</TableCell>
-                    <TableCell className="text-xs text-right">{sync.companies_found || 0}</TableCell>
-                    <TableCell className="text-xs text-right">{sync.companies_created || 0}</TableCell>
-                    <TableCell className="text-xs text-right">{sync.companies_updated || 0}</TableCell>
+                    <TableCell className="text-sm">{formatDate(sync.sync_started_at)}</TableCell>
+                    <TableCell className="text-sm">{getSyncStatusBadge(sync.status)}</TableCell>
+                    <TableCell className="text-sm text-right">{sync.companies_found || 0}</TableCell>
+                    <TableCell className="text-sm text-right">{sync.companies_created || 0}</TableCell>
+                    <TableCell className="text-sm text-right">{sync.companies_updated || 0}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/frontend/src/components/NotificationSettings.jsx
+++ b/frontend/src/components/NotificationSettings.jsx
@@ -51,7 +51,7 @@ const NotificationSettings = () => {
           port: data.port || 587,
           use_tls: data.use_tls === 1 || data.use_tls === true,
           username: data.username || '',
-          password: '', // Never return the actual password
+          password: '',
           auth_method: data.auth_method || 'plain',
           from_name: data.from_name || 'KARS Notifications',
           from_email: data.from_email || '',
@@ -71,7 +71,6 @@ const NotificationSettings = () => {
       ...settings,
       [name]: value
     });
-    // Clear error for this field if it exists
     if (errors[name]) {
       setErrors({ ...errors, [name]: null });
     }
@@ -102,10 +101,10 @@ const NotificationSettings = () => {
     e.preventDefault();
 
     if (!validateForm()) {
-      toast({ 
-        title: "Validation Error", 
-        description: 'Please fix the errors in the form', 
-        variant: "destructive" 
+      toast({
+        title: "Validation Error",
+        description: 'Please fix the errors in the form',
+        variant: "destructive"
       });
       return;
     }
@@ -125,7 +124,6 @@ const NotificationSettings = () => {
         default_recipient: settings.default_recipient || null
       };
 
-      // Only include password if it was changed
       if (settings.password && settings.password !== '[REDACTED]') {
         payload.password = settings.password;
       }
@@ -147,7 +145,6 @@ const NotificationSettings = () => {
 
       toast({ title: "Success", description: 'Notification settings saved successfully!' });
       setHasPassword(!!settings.password || hasPassword);
-      // Clear the password field after saving
       setSettings(prev => ({ ...prev, password: '' }));
     } catch (err) {
       toast({ title: "Error", description: err.message, variant: "destructive" });
@@ -158,10 +155,10 @@ const NotificationSettings = () => {
 
   const handleTestEmail = async () => {
     if (!settings.enabled) {
-      toast({ 
-        title: "Error", 
-        description: 'Please enable and save notification settings before sending a test email', 
-        variant: "destructive" 
+      toast({
+        title: "Error",
+        description: 'Please enable and save notification settings before sending a test email',
+        variant: "destructive"
       });
       return;
     }
@@ -193,8 +190,8 @@ const NotificationSettings = () => {
         throw new Error(data.error || 'Failed to send test email');
       }
 
-      toast({ 
-        title: "Success", 
+      toast({
+        title: "Success",
         description: data.message || 'Test email sent successfully!'
       });
       setTestDialogOpen(false);
@@ -207,24 +204,20 @@ const NotificationSettings = () => {
 
   if (loading) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-8 w-8 animate-spin text-primary" />
-          </div>
-        </CardContent>
-      </Card>
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
     );
   }
 
   return (
-    <div className="space-y-3">
-      <form onSubmit={handleSubmit} className="space-y-3">
-        {/* Enable Toggle */}
-        <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2 bg-muted/50">
+    <div className="space-y-4">
+      {/* SMTP Email Notifications - Main Container */}
+      <div className="rounded-lg border p-4">
+        <div className="flex items-center justify-between mb-4">
           <div>
-            <p className="font-medium text-sm">Enable SMTP Email Notifications</p>
-            <p className="text-xs text-muted-foreground">Configure SMTP settings for sending email notifications from KARS.</p>
+            <h3 className="text-sm font-semibold">SMTP Email Notifications</h3>
+            <p className="text-sm text-muted-foreground">Configure SMTP settings for sending email notifications from KARS.</p>
           </div>
           <Switch
             checked={settings.enabled}
@@ -232,145 +225,144 @@ const NotificationSettings = () => {
           />
         </div>
 
-        <div className="space-y-3">
-            {/* SMTP Server Settings */}
-            <div className="space-y-3 rounded-lg border p-3">
-              <h3 className="text-sm font-medium">SMTP Server</h3>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <Label htmlFor="host" className="text-xs">Host *</Label>
-                  <Input
-                    id="host"
-                    value={settings.host}
-                    onChange={(e) => handleChange('host', e.target.value)}
-                    placeholder="smtp.example.com"
-                    disabled={saving}
-                    className={errors.host ? 'border-destructive' : ''}
-                  />
-                  {errors.host && <p className="text-xs text-destructive">{errors.host}</p>}
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="port" className="text-xs">Port *</Label>
-                  <Input
-                    id="port"
-                    type="number"
-                    value={settings.port}
-                    onChange={(e) => handleChange('port', e.target.value)}
-                    placeholder="587"
-                    disabled={saving}
-                    className={errors.port ? 'border-destructive' : ''}
-                  />
-                  {errors.port && <p className="text-xs text-destructive">{errors.port}</p>}
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="use_tls"
-                  checked={settings.use_tls}
-                  onCheckedChange={(checked) => handleChange('use_tls', checked)}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* SMTP Server Settings */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">SMTP Server</h4>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="host" className="text-sm">Host *</Label>
+                <Input
+                  id="host"
+                  value={settings.host}
+                  onChange={(e) => handleChange('host', e.target.value)}
+                  placeholder="smtp.example.com"
                   disabled={saving}
+                  className={errors.host ? 'border-destructive' : ''}
                 />
-                <Label htmlFor="use_tls" className="text-xs cursor-pointer">Use TLS/SSL (recommended)</Label>
+                {errors.host && <p className="text-xs text-destructive">{errors.host}</p>}
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="port" className="text-sm">Port *</Label>
+                <Input
+                  id="port"
+                  type="number"
+                  value={settings.port}
+                  onChange={(e) => handleChange('port', e.target.value)}
+                  placeholder="587"
+                  disabled={saving}
+                  className={errors.port ? 'border-destructive' : ''}
+                />
+                {errors.port && <p className="text-xs text-destructive">{errors.port}</p>}
               </div>
             </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="use_tls"
+                checked={settings.use_tls}
+                onCheckedChange={(checked) => handleChange('use_tls', checked)}
+                disabled={saving}
+              />
+              <Label htmlFor="use_tls" className="text-sm cursor-pointer">Use TLS/SSL (recommended)</Label>
+            </div>
+          </div>
 
-            {/* Authentication */}
-            <div className="space-y-3 rounded-lg border p-3">
-              <h3 className="text-sm font-medium">Authentication</h3>
-              <div className="space-y-1">
-                <Label htmlFor="auth_method" className="text-xs">Auth Method</Label>
-                <Select value={settings.auth_method} onValueChange={(value) => handleChange('auth_method', value)}>
-                  <SelectTrigger id="auth_method" disabled={saving}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    <SelectItem value="plain">Plain</SelectItem>
-                    <SelectItem value="login">Login</SelectItem>
-                    <SelectItem value="cram-md5">CRAM-MD5</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              {settings.auth_method !== 'none' && (
-                <>
-                  <div className="space-y-1">
-                    <Label htmlFor="username" className="text-xs">Username</Label>
-                    <Input
-                      id="username"
-                      value={settings.username}
-                      onChange={(e) => handleChange('username', e.target.value)}
-                      placeholder="user@example.com"
-                      disabled={saving}
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label htmlFor="password" className="text-xs">
-                      Password
-                      {hasPassword && <span className="ml-1 text-muted-foreground">(leave blank to keep current)</span>}
-                    </Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      value={settings.password}
-                      onChange={(e) => handleChange('password', e.target.value)}
-                      placeholder={hasPassword ? '••••••••' : 'Enter password'}
-                      disabled={saving}
-                    />
-                  </div>
-                </>
-              )}
+          {/* Authentication */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Authentication</h4>
+            <div className="space-y-1.5">
+              <Label htmlFor="auth_method" className="text-sm">Auth Method</Label>
+              <Select value={settings.auth_method} onValueChange={(value) => handleChange('auth_method', value)}>
+                <SelectTrigger id="auth_method" disabled={saving}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  <SelectItem value="plain">Plain</SelectItem>
+                  <SelectItem value="login">Login</SelectItem>
+                  <SelectItem value="cram-md5">CRAM-MD5</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
+            {settings.auth_method !== 'none' && (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="username" className="text-sm">Username</Label>
+                  <Input
+                    id="username"
+                    value={settings.username}
+                    onChange={(e) => handleChange('username', e.target.value)}
+                    placeholder="user@example.com"
+                    disabled={saving}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="password" className="text-sm">
+                    Password
+                    {hasPassword && <span className="ml-1 text-muted-foreground text-xs">(leave blank to keep current)</span>}
+                  </Label>
+                  <Input
+                    id="password"
+                    type="password"
+                    value={settings.password}
+                    onChange={(e) => handleChange('password', e.target.value)}
+                    placeholder={hasPassword ? '••••••••' : 'Enter password'}
+                    disabled={saving}
+                  />
+                </div>
+              </>
+            )}
+          </div>
 
-            {/* Email Settings */}
-            <div className="space-y-3 rounded-lg border p-3">
-              <h3 className="text-sm font-medium">Email Settings</h3>
-              <div className="space-y-1">
-                <Label htmlFor="from_name" className="text-xs">From Name</Label>
-                <Input
-                  id="from_name"
-                  value={settings.from_name}
-                  onChange={(e) => handleChange('from_name', e.target.value)}
-                  placeholder="KARS Notifications"
-                  disabled={saving}
-                />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="from_email" className="text-xs">From Email *</Label>
-                <Input
-                  id="from_email"
-                  type="email"
-                  value={settings.from_email}
-                  onChange={(e) => handleChange('from_email', e.target.value)}
-                  placeholder="noreply@example.com"
-                  disabled={saving}
-                  className={errors.from_email ? 'border-destructive' : ''}
-                />
-                {errors.from_email && <p className="text-xs text-destructive">{errors.from_email}</p>}
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="default_recipient" className="text-xs">Default Test Recipient</Label>
-                <Input
-                  id="default_recipient"
-                  type="email"
-                  value={settings.default_recipient}
-                  onChange={(e) => handleChange('default_recipient', e.target.value)}
-                  placeholder="admin@example.com"
-                  disabled={saving}
-                />
-                <p className="text-xs text-muted-foreground">Used as the default recipient for test emails</p>
-              </div>
+          {/* Email Settings */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Email Settings</h4>
+            <div className="space-y-1.5">
+              <Label htmlFor="from_name" className="text-sm">From Name</Label>
+              <Input
+                id="from_name"
+                value={settings.from_name}
+                onChange={(e) => handleChange('from_name', e.target.value)}
+                placeholder="KARS Notifications"
+                disabled={saving}
+              />
             </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="from_email" className="text-sm">From Email *</Label>
+              <Input
+                id="from_email"
+                type="email"
+                value={settings.from_email}
+                onChange={(e) => handleChange('from_email', e.target.value)}
+                placeholder="noreply@example.com"
+                disabled={saving}
+                className={errors.from_email ? 'border-destructive' : ''}
+              />
+              {errors.from_email && <p className="text-xs text-destructive">{errors.from_email}</p>}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="default_recipient" className="text-sm">Default Test Recipient</Label>
+              <Input
+                id="default_recipient"
+                type="email"
+                value={settings.default_recipient}
+                onChange={(e) => handleChange('default_recipient', e.target.value)}
+                placeholder="admin@example.com"
+                disabled={saving}
+              />
+              <p className="text-sm text-muted-foreground">Used as the default recipient for test emails</p>
+            </div>
+          </div>
 
           {/* Actions */}
           <div className="flex gap-2 pt-2">
-            <Button type="submit" disabled={saving} size="sm">
+            <Button type="submit" disabled={saving}>
               {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               Save Settings
             </Button>
             <Button
               type="button"
               variant="outline"
-              size="sm"
               onClick={handleTestEmail}
               disabled={!settings.enabled || saving}
             >
@@ -378,15 +370,15 @@ const NotificationSettings = () => {
               Send Test Email
             </Button>
           </div>
-        </div>
-      </form>
+        </form>
+      </div>
 
       {/* Security Notice */}
       <Alert>
         <Info className="h-4 w-4" />
-        <AlertDescription className="text-xs">
-          <strong>Security:</strong> SMTP passwords are encrypted at rest using AES-256-GCM encryption. 
-          Ensure the <code>KARS_MASTER_KEY</code> environment variable is set and kept secure.
+        <AlertDescription className="text-sm">
+          <strong>Security:</strong> SMTP passwords are encrypted at rest using AES-256-GCM encryption.
+          Ensure the <code className="bg-muted px-1 py-0.5 rounded">KARS_MASTER_KEY</code> environment variable is set and kept secure.
         </AlertDescription>
       </Alert>
 

--- a/frontend/src/components/OIDCSettings.jsx
+++ b/frontend/src/components/OIDCSettings.jsx
@@ -114,12 +114,11 @@ const OIDCSettings = () => {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-3">
-      {/* Enable Toggle */}
-      <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2 bg-muted/50">
+    <div className="rounded-lg border p-4">
+      <div className="flex items-center justify-between mb-4">
         <div>
-          <p className="font-medium text-sm">Enable OIDC/SSO Authentication</p>
-          <p className="text-xs text-muted-foreground">Allow users to sign in with an external identity provider.</p>
+          <h3 className="text-sm font-semibold">OIDC/SSO Authentication</h3>
+          <p className="text-sm text-muted-foreground">Allow users to sign in with an external identity provider.</p>
         </div>
         <Switch
           id="oidc-enabled"
@@ -128,202 +127,200 @@ const OIDCSettings = () => {
         />
       </div>
 
-      {/* Provider Configuration */}
-      <div className="space-y-3 rounded-lg border p-3">
-        <h3 className="text-sm font-medium">Provider Configuration</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Provider Configuration */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-muted-foreground">Provider Configuration</h4>
 
-        <div className="space-y-1.5">
-          <Label htmlFor="issuer_url" className="text-xs">Issuer URL {settings.enabled && <span className="text-destructive">*</span>}</Label>
-          <Input
-            id="issuer_url"
-            name="issuer_url"
-            value={settings.issuer_url}
-            onChange={(e) => handleChange('issuer_url', e.target.value)}
-            required={settings.enabled}
-            disabled={!settings.enabled}
-            placeholder="https://your-domain.auth0.com"
-          />
-          <p className="text-xs text-muted-foreground">
-            The OIDC issuer URL from your identity provider
-          </p>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="client_id" className="text-xs">Client ID {settings.enabled && <span className="text-destructive">*</span>}</Label>
-          <Input
-            id="client_id"
-            name="client_id"
-            value={settings.client_id}
-            onChange={(e) => handleChange('client_id', e.target.value)}
-            required={settings.enabled}
-            disabled={!settings.enabled}
-            placeholder="your-client-id"
-          />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="client_secret" className="text-xs">
-            Client Secret {settings.enabled && !hasClientSecret && <span className="text-destructive">*</span>}
-          </Label>
-          <Input
-            id="client_secret"
-            name="client_secret"
-            type="password"
-            value={settings.client_secret}
-            onChange={(e) => handleChange('client_secret', e.target.value)}
-            required={settings.enabled && !hasClientSecret}
-            disabled={!settings.enabled}
-            placeholder={hasClientSecret ? "••••••••••••" : "your-client-secret"}
-          />
-          {hasClientSecret && (
-            <p className="text-xs text-muted-foreground">
-              Leave blank to keep existing secret
+          <div className="space-y-1.5">
+            <Label htmlFor="issuer_url" className="text-sm">Issuer URL {settings.enabled && <span className="text-destructive">*</span>}</Label>
+            <Input
+              id="issuer_url"
+              name="issuer_url"
+              value={settings.issuer_url}
+              onChange={(e) => handleChange('issuer_url', e.target.value)}
+              required={settings.enabled}
+              disabled={!settings.enabled}
+              placeholder="https://your-domain.auth0.com"
+            />
+            <p className="text-sm text-muted-foreground">
+              The OIDC issuer URL from your identity provider
             </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="client_id" className="text-sm">Client ID {settings.enabled && <span className="text-destructive">*</span>}</Label>
+            <Input
+              id="client_id"
+              name="client_id"
+              value={settings.client_id}
+              onChange={(e) => handleChange('client_id', e.target.value)}
+              required={settings.enabled}
+              disabled={!settings.enabled}
+              placeholder="your-client-id"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="client_secret" className="text-sm">
+              Client Secret {settings.enabled && !hasClientSecret && <span className="text-destructive">*</span>}
+            </Label>
+            <Input
+              id="client_secret"
+              name="client_secret"
+              type="password"
+              value={settings.client_secret}
+              onChange={(e) => handleChange('client_secret', e.target.value)}
+              required={settings.enabled && !hasClientSecret}
+              disabled={!settings.enabled}
+              placeholder={hasClientSecret ? "••••••••••••" : "your-client-secret"}
+            />
+            {hasClientSecret && (
+              <p className="text-sm text-muted-foreground">
+                Leave blank to keep existing secret
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="redirect_uri" className="text-sm">Redirect URI {settings.enabled && <span className="text-destructive">*</span>}</Label>
+            <Input
+              id="redirect_uri"
+              name="redirect_uri"
+              value={settings.redirect_uri}
+              onChange={(e) => handleChange('redirect_uri', e.target.value)}
+              required={settings.enabled}
+              disabled={!settings.enabled}
+              placeholder={window.location.origin + "/auth/callback"}
+            />
+            <p className="text-sm text-muted-foreground">
+              Configure this URL in your OIDC provider's allowed callback URLs
+            </p>
+          </div>
+        </div>
+
+        {/* Advanced Settings */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-muted-foreground">Advanced Settings</h4>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="scope" className="text-sm">Scopes</Label>
+            <Input
+              id="scope"
+              name="scope"
+              value={settings.scope}
+              onChange={(e) => handleChange('scope', e.target.value)}
+              disabled={!settings.enabled}
+              placeholder="openid email profile"
+            />
+            <p className="text-sm text-muted-foreground">
+              Space-separated list of OAuth scopes
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="role_claim_path" className="text-sm">Role Claim Path</Label>
+            <Input
+              id="role_claim_path"
+              name="role_claim_path"
+              value={settings.role_claim_path}
+              onChange={(e) => handleChange('role_claim_path', e.target.value)}
+              disabled={!settings.enabled}
+              placeholder="roles"
+            />
+            <p className="text-sm text-muted-foreground">
+              Path to the roles claim in the OIDC token (e.g., 'roles', 'groups')
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="default_role" className="text-sm">Default Role</Label>
+            <Select
+              value={settings.default_role}
+              onValueChange={(value) => handleChange('default_role', value)}
+              disabled={!settings.enabled}
+            >
+              <SelectTrigger id="default_role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="employee">Employee</SelectItem>
+                <SelectItem value="manager">Manager</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-sm text-muted-foreground">
+              Default role for new users if no role mapping matches
+            </p>
+          </div>
+        </div>
+
+        {/* Button Customization */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-muted-foreground">Sign-in Button Customization</h4>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="sso_button_text" className="text-sm">Button Label</Label>
+            <Input
+              id="sso_button_text"
+              name="sso_button_text"
+              value={settings.sso_button_text}
+              onChange={(e) => handleChange('sso_button_text', e.target.value)}
+              disabled={!settings.enabled}
+              placeholder="Sign In with SSO"
+            />
+            <p className="text-sm text-muted-foreground">Set the text users see on the sign-in button.</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="sso_button_help_text" className="text-sm">Helper Text (optional)</Label>
+            <Textarea
+              id="sso_button_help_text"
+              name="sso_button_help_text"
+              value={settings.sso_button_help_text}
+              onChange={(e) => handleChange('sso_button_help_text', e.target.value)}
+              disabled={!settings.enabled}
+              placeholder="Use your company identity provider."
+              className="min-h-[60px]"
+            />
+            <p className="text-sm text-muted-foreground">Appears below the button on the sign-in page.</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="sso_button_variant" className="text-sm">Button Style</Label>
+            <Select
+              value={settings.sso_button_variant}
+              onValueChange={(value) => handleChange('sso_button_variant', value)}
+              disabled={!settings.enabled}
+            >
+              <SelectTrigger id="sso_button_variant">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Primary</SelectItem>
+                <SelectItem value="secondary">Muted</SelectItem>
+                <SelectItem value="outline">Outline</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-sm text-muted-foreground">Match your branding by selecting a button variant.</p>
+          </div>
+        </div>
+
+        <Button type="submit" disabled={saving}>
+          {saving ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save className="h-4 w-4 mr-2" />
+              Save OIDC Settings
+            </>
           )}
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="redirect_uri" className="text-xs">Redirect URI {settings.enabled && <span className="text-destructive">*</span>}</Label>
-          <Input
-            id="redirect_uri"
-            name="redirect_uri"
-            value={settings.redirect_uri}
-            onChange={(e) => handleChange('redirect_uri', e.target.value)}
-            required={settings.enabled}
-            disabled={!settings.enabled}
-            placeholder={window.location.origin + "/auth/callback"}
-          />
-          <p className="text-xs text-muted-foreground">
-            Configure this URL in your OIDC provider's allowed callback URLs
-          </p>
-        </div>
-      </div>
-
-      {/* Advanced Settings */}
-      <div className="space-y-3 rounded-lg border p-3">
-        <h3 className="text-sm font-medium">Advanced Settings</h3>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="scope" className="text-xs">Scopes</Label>
-          <Input
-            id="scope"
-            name="scope"
-            value={settings.scope}
-            onChange={(e) => handleChange('scope', e.target.value)}
-            disabled={!settings.enabled}
-            placeholder="openid email profile"
-          />
-          <p className="text-xs text-muted-foreground">
-            Space-separated list of OAuth scopes
-          </p>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="role_claim_path" className="text-xs">Role Claim Path</Label>
-          <Input
-            id="role_claim_path"
-            name="role_claim_path"
-            value={settings.role_claim_path}
-            onChange={(e) => handleChange('role_claim_path', e.target.value)}
-            disabled={!settings.enabled}
-            placeholder="roles"
-          />
-          <p className="text-xs text-muted-foreground">
-            Path to the roles claim in the OIDC token (e.g., 'roles', 'groups', 'https://myapp.com/roles')
-          </p>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="default_role" className="text-xs">Default Role</Label>
-          <Select
-            value={settings.default_role}
-            onValueChange={(value) => handleChange('default_role', value)}
-            disabled={!settings.enabled}
-          >
-            <SelectTrigger id="default_role">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="employee">Employee</SelectItem>
-              <SelectItem value="manager">Manager</SelectItem>
-              <SelectItem value="admin">Admin</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Default role for new users if no role mapping matches
-          </p>
-        </div>
-      </div>
-
-      {/* Button Customization */}
-      <div className="space-y-3 rounded-lg border p-3">
-        <h3 className="text-sm font-medium">Sign-in Button Customization</h3>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="sso_button_text" className="text-xs">Button label</Label>
-          <Input
-            id="sso_button_text"
-            name="sso_button_text"
-            value={settings.sso_button_text}
-            onChange={(e) => handleChange('sso_button_text', e.target.value)}
-            disabled={!settings.enabled}
-            placeholder="Sign In with SSO"
-          />
-          <p className="text-xs text-muted-foreground">Set the text users see on the sign-in button.</p>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="sso_button_help_text" className="text-xs">Helper text (optional)</Label>
-          <Textarea
-            id="sso_button_help_text"
-            name="sso_button_help_text"
-            value={settings.sso_button_help_text}
-            onChange={(e) => handleChange('sso_button_help_text', e.target.value)}
-            disabled={!settings.enabled}
-            placeholder="Use your company identity provider."
-            className="min-h-[60px]"
-          />
-          <p className="text-xs text-muted-foreground">Appears below the button on the sign-in page.</p>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="sso_button_variant" className="text-xs">Button style</Label>
-          <Select
-            value={settings.sso_button_variant}
-            onValueChange={(value) => handleChange('sso_button_variant', value)}
-            disabled={!settings.enabled}
-          >
-            <SelectTrigger id="sso_button_variant">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="default">Primary</SelectItem>
-              <SelectItem value="secondary">Muted</SelectItem>
-              <SelectItem value="outline">Outline</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">Match your branding by selecting a button variant.</p>
-        </div>
-      </div>
-
-      <Button
-        type="submit"
-        disabled={saving}
-        size="sm"
-      >
-        {saving ? (
-          <>
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-            Saving...
-          </>
-        ) : (
-          <>
-            <Save className="h-4 w-4 mr-2" />
-            Save OIDC Settings
-          </>
-        )}
-      </Button>
-    </form>
+        </Button>
+      </form>
+    </div>
   );
 };
 

--- a/frontend/src/components/SecuritySettings.jsx
+++ b/frontend/src/components/SecuritySettings.jsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Switch } from '@/components/ui/switch';
-import { Fingerprint, Key, Loader2, AlertTriangle, Info, ExternalLink } from 'lucide-react';
+import { Fingerprint, Loader2, AlertTriangle, Info, ExternalLink, Save } from 'lucide-react';
 import OIDCSettings from './OIDCSettings';
 
 const SecuritySettings = () => {
@@ -69,36 +67,29 @@ const SecuritySettings = () => {
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {/* Passkey/WebAuthn Configuration */}
-      <Card>
-        <CardHeader className="pb-2">
-          <div className="flex items-center gap-2">
-            <Fingerprint className="h-5 w-5 text-primary" />
-            <CardTitle className="text-base">Passkey/WebAuthn Configuration</CardTitle>
+      <div className="rounded-lg border p-4">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-sm font-semibold">Passkey/WebAuthn Authentication</h3>
+            <p className="text-sm text-muted-foreground">
+              Configure biometric authentication (Touch ID, Face ID, Windows Hello) and hardware security keys.
+            </p>
           </div>
-          <CardDescription className="text-sm">
-            Configure biometric authentication (Touch ID, Face ID, Windows Hello) and hardware security keys (YubiKey)
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 pt-2">
-          <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2 bg-muted/50">
-            <div>
-              <p className="font-medium text-sm">Passkey sign-in</p>
-              <p className="text-xs text-muted-foreground">Toggle to allow users to register and sign in with passkeys.</p>
-            </div>
-            <Switch
-              checked={passkeySettings.enabled}
-              onCheckedChange={(checked) => setPasskeySettings({ ...passkeySettings, enabled: checked })}
-              disabled={passkeySettings.managed_by_env || loading}
-            />
-          </div>
+          <Switch
+            checked={passkeySettings.enabled}
+            onCheckedChange={(checked) => setPasskeySettings({ ...passkeySettings, enabled: checked })}
+            disabled={passkeySettings.managed_by_env || loading}
+          />
+        </div>
 
+        <div className="space-y-4">
           {!passkeySettings.enabled && (
             <Alert variant="warning" className="py-2">
               <AlertTriangle className="h-4 w-4" />
-              <AlertDescription className="text-xs">
-                Passkey registration and sign-in are currently disabled. Users will not see passkey options on the login page while this is off.
+              <AlertDescription className="text-sm">
+                Passkey registration and sign-in are currently disabled. Users will not see passkey options on the login page.
               </AlertDescription>
             </Alert>
           )}
@@ -106,87 +97,94 @@ const SecuritySettings = () => {
           {passkeySettings.managed_by_env && (
             <Alert variant="warning" className="py-2">
               <AlertTriangle className="h-4 w-4" />
-              <AlertDescription className="text-xs">
-                Passkey settings are currently managed by environment variables. To use database configuration, remove PASSKEY_RP_ID, PASSKEY_RP_NAME, PASSKEY_ORIGIN, and PASSKEY_ENABLED from your environment variables and restart the backend.
+              <AlertDescription className="text-sm">
+                Passkey settings are managed by environment variables. Remove PASSKEY_RP_ID, PASSKEY_RP_NAME, PASSKEY_ORIGIN, and PASSKEY_ENABLED from your environment and restart the backend to use database configuration.
               </AlertDescription>
             </Alert>
           )}
 
           <Alert className="py-2">
             <Info className="h-4 w-4" />
-            <AlertDescription className="text-xs">
+            <AlertDescription className="text-sm">
               <strong>Restart required:</strong> Changes to passkey settings require a backend restart to take effect.
             </AlertDescription>
           </Alert>
 
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="rp_id" className="text-sm">Relying Party ID (RP ID) *</Label>
-              <Input
-                id="rp_id"
-                value={passkeySettings.rp_id}
-                onChange={(e) => setPasskeySettings({ ...passkeySettings, rp_id: e.target.value })}
-                disabled={passkeySettings.managed_by_env || loading}
-                placeholder="localhost"
-                className="h-9"
-              />
-              <p className="text-xs text-muted-foreground">
-                Domain name without protocol (e.g., 'localhost' or 'example.com'). MUST match the domain users access the app from.
-              </p>
-              <Alert className="mt-1 py-2">
-                <AlertDescription className="text-xs space-y-0.5">
-                  <p><strong>Local Development:</strong></p>
-                  <p>• Set to: <code className="bg-muted px-1 py-0.5 rounded text-xs">localhost</code></p>
-                  <p>• Access via: <code className="bg-muted px-1 py-0.5 rounded text-xs">http://localhost:5173</code></p>
-                  <p>⚠️ DO NOT access via <code className="bg-muted px-1 py-0.5 rounded text-xs">127.0.0.1</code></p>
-                </AlertDescription>
-              </Alert>
+          {/* Configuration */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Configuration</h4>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="rp_id" className="text-sm">Relying Party ID (RP ID) *</Label>
+                <Input
+                  id="rp_id"
+                  value={passkeySettings.rp_id}
+                  onChange={(e) => setPasskeySettings({ ...passkeySettings, rp_id: e.target.value })}
+                  disabled={passkeySettings.managed_by_env || loading}
+                  placeholder="localhost"
+                />
+                <p className="text-sm text-muted-foreground">
+                  Domain name without protocol (e.g., 'localhost' or 'example.com')
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="rp_name" className="text-sm">Relying Party Name *</Label>
+                <Input
+                  id="rp_name"
+                  value={passkeySettings.rp_name}
+                  onChange={(e) => setPasskeySettings({ ...passkeySettings, rp_name: e.target.value })}
+                  disabled={passkeySettings.managed_by_env || loading}
+                  placeholder="KARS - KeyData Asset Registration System"
+                />
+                <p className="text-sm text-muted-foreground">
+                  Friendly name shown to users during passkey registration
+                </p>
+              </div>
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="rp_name" className="text-sm">Relying Party Name (RP Name) *</Label>
+              <Label htmlFor="origin" className="text-sm">Expected Origin *</Label>
               <Input
-                id="rp_name"
-                value={passkeySettings.rp_name}
-                onChange={(e) => setPasskeySettings({ ...passkeySettings, rp_name: e.target.value })}
+                id="origin"
+                value={passkeySettings.origin}
+                onChange={(e) => setPasskeySettings({ ...passkeySettings, origin: e.target.value })}
                 disabled={passkeySettings.managed_by_env || loading}
-                placeholder="KARS - KeyData Asset Registration System"
-                className="h-9"
+                placeholder="http://localhost:5173 or https://example.com"
               />
-              <p className="text-xs text-muted-foreground">
-                Friendly name shown to users during passkey registration
+              <p className="text-sm text-muted-foreground">
+                Full URL with protocol where your frontend is hosted
               </p>
-              <Alert className="mt-1 py-2">
-                <AlertDescription className="text-xs space-y-0.5">
-                  <p><strong>Production:</strong></p>
-                  <p>• Set to: <code className="bg-muted px-1 py-0.5 rounded text-xs">yourdomain.com</code></p>
-                  <p>• Access via: <code className="bg-muted px-1 py-0.5 rounded text-xs">https://yourdomain.com</code></p>
-                  <p>• Can also use subdomain: <code className="bg-muted px-1 py-0.5 rounded text-xs">app.example.com</code></p>
-                </AlertDescription>
-              </Alert>
             </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="origin" className="text-sm">Expected Origin *</Label>
-            <Input
-              id="origin"
-              value={passkeySettings.origin}
-              onChange={(e) => setPasskeySettings({ ...passkeySettings, origin: e.target.value })}
-              disabled={passkeySettings.managed_by_env || loading}
-              placeholder="http://localhost:5173 or https://example.com"
-              className="h-9"
-            />
-            <p className="text-xs text-muted-foreground">
-              Full URL with protocol where your frontend is hosted
-            </p>
+          {/* Tips */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">Configuration Tips</h4>
+            <div className="grid gap-3 md:grid-cols-2">
+              <Alert className="py-2">
+                <AlertDescription className="text-sm space-y-1">
+                  <p><strong>Local Development:</strong></p>
+                  <p>• RP ID: <code className="bg-muted px-1 py-0.5 rounded">localhost</code></p>
+                  <p>• Origin: <code className="bg-muted px-1 py-0.5 rounded">http://localhost:5173</code></p>
+                  <p className="text-muted-foreground">⚠️ Don't use 127.0.0.1</p>
+                </AlertDescription>
+              </Alert>
+              <Alert className="py-2">
+                <AlertDescription className="text-sm space-y-1">
+                  <p><strong>Production:</strong></p>
+                  <p>• RP ID: <code className="bg-muted px-1 py-0.5 rounded">yourdomain.com</code></p>
+                  <p>• Origin: <code className="bg-muted px-1 py-0.5 rounded">https://yourdomain.com</code></p>
+                </AlertDescription>
+              </Alert>
+            </div>
           </div>
 
           <div className="flex items-center gap-2">
             <Button
               onClick={handlePasskeySave}
               disabled={passkeySettings.managed_by_env || loading}
-              size="sm"
             >
               {loading ? (
                 <>
@@ -195,7 +193,7 @@ const SecuritySettings = () => {
                 </>
               ) : (
                 <>
-                  <Fingerprint className="h-4 w-4 mr-2" />
+                  <Save className="h-4 w-4 mr-2" />
                   Save Passkey Settings
                 </>
               )}
@@ -205,7 +203,7 @@ const SecuritySettings = () => {
               href="https://github.com/humac/kars/blob/main/PASSKEY-TROUBLESHOOTING.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-primary hover:underline flex items-center gap-1"
+              className="text-sm text-primary hover:underline flex items-center gap-1"
             >
               <Info className="h-3 w-3" />
               Troubleshooting Guide
@@ -216,36 +214,23 @@ const SecuritySettings = () => {
           {!passkeySettings.managed_by_env && (
             <Alert variant="warning" className="py-2">
               <AlertTriangle className="h-4 w-4" />
-              <AlertDescription className="text-xs">
+              <AlertDescription className="text-sm">
                 After saving, you must restart the backend for changes to take effect.
               </AlertDescription>
             </Alert>
           )}
 
           {passkeySettings.updated_at && (
-            <div className="pt-2 border-t text-xs text-muted-foreground">
+            <div className="pt-2 border-t text-sm text-muted-foreground">
               Last updated: {new Date(passkeySettings.updated_at).toLocaleString()}
               {passkeySettings.updated_by && ` by ${passkeySettings.updated_by}`}
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
       {/* OIDC/SSO Configuration */}
-      <Card>
-        <CardHeader className="pb-2">
-          <div className="flex items-center gap-2">
-            <Key className="h-5 w-5 text-primary" />
-            <CardTitle className="text-base">OIDC/SSO Configuration</CardTitle>
-          </div>
-          <CardDescription className="text-sm">
-            Configure Single Sign-On authentication providers
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="pt-2">
-          <OIDCSettings />
-        </CardContent>
-      </Card>
+      <OIDCSettings />
     </div>
   );
 };


### PR DESCRIPTION
- Fix NotificationSettings blank screen (removed Card import reference)
- Standardize all settings components with consistent structure:
  - Each feature has title + enable toggle + sub-settings in one bordered container
  - Removed background shading (bg-muted/50) from enable toggles
  - Use consistent text-sm font size for labels and descriptions
  - Use consistent p-4 padding for main containers
  - Use consistent space-y-4 spacing between sections
- Remove unused Card/CardContent/CardHeader imports
- Update all Labels to text-sm, descriptions to text-sm text-muted-foreground
- Simplify SecuritySettings layout (removed nested Cards)