### PR TITLE
feat: Normalize company-asset relationship using company_id FK

### DIFF
--- a/backend/asset-authorization.test.js
+++ b/backend/asset-authorization.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
-import { assetDb, userDb, auditDb } from './database.js';
+import { assetDb, userDb, auditDb, companyDb } from './database.js';
 
 describe('Asset Authorization and Manager Sync', () => {
   let testDb;
@@ -7,10 +7,18 @@ describe('Asset Authorization and Manager Sync', () => {
   let managerUser;
   let adminUser;
   let asset;
+  let testCompany;
 
   beforeAll(async () => {
     // Initialize database
     await assetDb.init();
+
+    // Create test company (required for assets with company_id FK)
+    const companyResult = await companyDb.create({
+      name: 'Test Company',
+      description: 'Test company for authorization tests'
+    });
+    testCompany = await companyDb.getById(companyResult.id);
 
     // Create test users
     const employeeResult = await userDb.create({
@@ -71,6 +79,7 @@ describe('Asset Authorization and Manager Sync', () => {
     if (employeeUser) await userDb.delete(employeeUser.id);
     if (managerUser) await userDb.delete(managerUser.id);
     if (adminUser) await userDb.delete(adminUser.id);
+    if (testCompany) await companyDb.delete(testCompany.id);
   });
 
   describe('Asset Creation with IDs', () => {

--- a/backend/asset-ownership-sync.test.js
+++ b/backend/asset-ownership-sync.test.js
@@ -1,14 +1,22 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
-import { assetDb, userDb, syncAssetOwnership } from './database.js';
+import { assetDb, userDb, syncAssetOwnership, companyDb } from './database.js';
 
 describe('Asset Ownership Sync', () => {
   let employeeUser;
   let managerUser;
   let preloadedAsset;
+  let testCompany;
 
   beforeAll(async () => {
     // Initialize database
     await assetDb.init();
+
+    // Create test company (required for assets with company_id FK)
+    const companyResult = await companyDb.create({
+      name: 'Test Company',
+      description: 'Test company for ownership sync tests'
+    });
+    testCompany = await companyDb.getById(companyResult.id);
   });
 
   beforeEach(async () => {
@@ -47,6 +55,13 @@ describe('Asset Ownership Sync', () => {
     if (managerUser) {
       try {
         await userDb.delete(managerUser.id);
+      } catch (err) {
+        // Ignore errors
+      }
+    }
+    if (testCompany) {
+      try {
+        await companyDb.delete(testCompany.id);
       } catch (err) {
         // Ignore errors
       }

--- a/backend/performance.test.js
+++ b/backend/performance.test.js
@@ -6,11 +6,30 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
-import { assetDb, userDb, auditDb } from './database.js';
+import { assetDb, userDb, auditDb, companyDb } from './database.js';
 
 describe('Performance Optimizations', () => {
+  let testCompany;
+
   beforeAll(async () => {
     await assetDb.init();
+    // Create test company (required for assets with company_id FK)
+    const companyResult = await companyDb.create({
+      name: 'Test Company',
+      description: 'Test company for performance tests'
+    });
+    testCompany = await companyDb.getById(companyResult.id);
+  });
+
+  afterAll(async () => {
+    // Clean up test company
+    if (testCompany) {
+      try {
+        await companyDb.delete(testCompany.id);
+      } catch (err) {
+        // May have assets still referencing it
+      }
+    }
   });
 
   beforeEach(async () => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -3277,7 +3277,7 @@ app.delete('/api/companies/:id', authenticate, authorize('admin'), async (req, r
     }
 
     // Check if company has assets
-    if (await companyDb.hasAssets(company.name)) {
+    if (await companyDb.hasAssets(company.id)) {
       return res.status(409).json({
         error: 'Cannot delete company with existing assets. Please reassign or delete assets first.'
       });

--- a/backend/unregistered-manager.test.js
+++ b/backend/unregistered-manager.test.js
@@ -1,14 +1,22 @@
 import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
-import { assetDb, userDb } from './database.js';
+import { assetDb, userDb, companyDb } from './database.js';
 
 describe('Unregistered Manager Name Display', () => {
   let testAssetId;
   let employeeUser;
   let registeredManagerUser;
+  let testCompany;
 
   beforeAll(async () => {
     // Initialize database
     await assetDb.init();
+
+    // Create test company (required for assets with company_id FK)
+    const companyResult = await companyDb.create({
+      name: 'Test Company',
+      description: 'Test company for unregistered manager tests'
+    });
+    testCompany = await companyDb.getById(companyResult.id);
 
     // Create an employee user
     const employeeResult = await userDb.create({
@@ -28,6 +36,7 @@ describe('Unregistered Manager Name Display', () => {
     if (testAssetId) await assetDb.delete(testAssetId);
     if (employeeUser) await userDb.delete(employeeUser.id);
     if (registeredManagerUser) await userDb.delete(registeredManagerUser.id);
+    if (testCompany) await companyDb.delete(testCompany.id);
   });
 
   describe('Asset Creation with Unregistered Manager', () => {


### PR DESCRIPTION
Replace denormalized company_name with company_id foreign key reference to ensure company name changes automatically propagate to all assets.

Changes:
- Update assets table schema to use company_id INTEGER FK instead of company_name TEXT
- Add INNER JOIN with companies table in all asset queries to return company_name
- Update assetDb.create() and update() to lookup company_id from company_name
- Update companyDb.hasAssets() to use company_id instead of company_name
- Add companyDb.getAssetCount() helper method
- Update server.js to pass company.id to hasAssets()
- Update test files to create test companies before asset operations

The API remains backward compatible - it still accepts company_name in requests and returns company_name in responses via the JOIN.