### PR TITLE
Remember previous certification results in follow-up attestations

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -92,7 +92,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ${{ matrix.project }}-coverage
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -205,14 +205,14 @@ jobs:
           npx playwright test
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report
           path: frontend/playwright-report/
 
       - name: Upload E2E JUnit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: e2e-junit-results

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -83,7 +83,7 @@ jobs:
     environment: 'KARS Application / sbx'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Deploy Frontend (Dev)
         run: npx @railway/cli redeploy --service ${{ secrets.RAILWAY_FRONTEND_ID_DEV }} --yes

--- a/.github/workflows/verify-files.yml
+++ b/.github/workflows/verify-files.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Verify critical files are complete
       run: |

--- a/backend/asset-self-edit-regression.test.js
+++ b/backend/asset-self-edit-regression.test.js
@@ -1,0 +1,111 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { assetDb, companyDb, userDb } from './database.js';
+import { requireAssetPermission } from './middleware/authorization.js';
+
+const createdAssetIds = [];
+const createdUserIds = [];
+const createdCompanyIds = [];
+
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+describe('Asset self-edit regression', () => {
+  beforeAll(async () => {
+    await assetDb.init();
+  });
+
+  afterEach(async () => {
+    while (createdAssetIds.length) {
+      await assetDb.delete(createdAssetIds.pop());
+    }
+
+    while (createdUserIds.length) {
+      await userDb.delete(createdUserIds.pop());
+    }
+
+    while (createdCompanyIds.length) {
+      await companyDb.delete(createdCompanyIds.pop());
+    }
+  });
+
+  it('preserves employee identity fields and ownership when an employee updates their own asset', async () => {
+    const suffix = uniqueSuffix();
+    const companyResult = await companyDb.create({
+      name: `Regression Co ${suffix}`,
+      description: 'Asset self-edit regression test'
+    });
+    createdCompanyIds.push(companyResult.id);
+
+    await userDb.create({
+      email: `employee-${suffix}@test.com`,
+      password_hash: 'hash',
+      name: 'Employee Regression',
+      role: 'employee',
+      first_name: 'Emily',
+      last_name: 'Owner'
+    });
+    const employee = await userDb.getByEmail(`employee-${suffix}@test.com`);
+    createdUserIds.push(employee.id);
+
+    const assetResult = await assetDb.create({
+      employee_first_name: 'Emily',
+      employee_last_name: 'Owner',
+      employee_email: employee.email,
+      company_name: `Regression Co ${suffix}`,
+      asset_type: 'laptop',
+      make: 'Dell',
+      model: 'Latitude',
+      serial_number: `SELF-EDIT-${suffix}`,
+      asset_tag: `SELF-EDIT-TAG-${suffix}`,
+      status: 'active',
+      notes: 'Before update'
+    });
+    createdAssetIds.push(assetResult.id);
+
+    // Simulate the non-admin route behavior after forbidden ownership fields are stripped.
+    await assetDb.update(assetResult.id, {
+      company_name: `Regression Co ${suffix}`,
+      asset_type: 'laptop',
+      make: 'Lenovo',
+      model: 'T14',
+      serial_number: `SELF-EDIT-${suffix}`,
+      asset_tag: `SELF-EDIT-TAG-${suffix}`,
+      status: 'active',
+      notes: 'Updated by owner'
+    });
+
+    const reloadedAsset = await assetDb.getById(assetResult.id);
+    expect(reloadedAsset).toEqual(expect.objectContaining({
+      employee_first_name: 'Emily',
+      employee_last_name: 'Owner',
+      employee_email: employee.email,
+      owner_id: employee.id,
+      make: 'Lenovo',
+      model: 'T14',
+      notes: 'Updated by owner'
+    }));
+
+    const req = {
+      params: { id: String(assetResult.id) },
+      user: { id: employee.id },
+      asset: reloadedAsset
+    };
+    const res = {
+      statusCode: 200,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.body = payload;
+        return this;
+      }
+    };
+    const next = jest.fn();
+
+    await requireAssetPermission(assetDb, userDb)(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/attestation-campaign-eligibility.test.js
+++ b/backend/attestation-campaign-eligibility.test.js
@@ -1,0 +1,455 @@
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+
+import {
+  assetDb,
+  attestationAssetDb,
+  attestationCampaignDb,
+  attestationRecordDb,
+  companyDb,
+  userDb
+} from './database.js';
+import {
+  filterCampaignTargetsByEligibleAssets,
+  getEligibleAssetsForCampaignUser
+} from './routes/attestation.js';
+
+const createdCampaignIds = [];
+const createdAssetIds = [];
+const createdUserIds = [];
+const createdCompanyIds = [];
+
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const remember = (collection, value) => {
+  collection.push(value);
+  return value;
+};
+
+const createUser = async ({ suffix, role = 'employee', emailPrefix, firstName, lastName, managerEmail = null }) => {
+  const email = `${emailPrefix}-${suffix}@test.com`;
+  await userDb.create({
+    email,
+    password_hash: 'hash',
+    name: `${firstName} ${lastName}`,
+    role,
+    first_name: firstName,
+    last_name: lastName,
+    manager_email: managerEmail
+  });
+  const user = await userDb.getByEmail(email);
+  remember(createdUserIds, user.id);
+  return user;
+};
+
+const createCompany = async (suffix, namePrefix = 'Eligibility Co') => {
+  const result = await companyDb.create({
+    name: `${namePrefix} ${suffix}`,
+    description: 'Attestation eligibility test company'
+  });
+  remember(createdCompanyIds, result.id);
+  return companyDb.getById(result.id);
+};
+
+const createAsset = async (asset) => {
+  const result = await assetDb.create(asset);
+  remember(createdAssetIds, result.id);
+  return assetDb.getById(result.id);
+};
+
+const createCampaign = async (campaign) => {
+  const result = await attestationCampaignDb.create(campaign);
+  remember(createdCampaignIds, result.id);
+  return attestationCampaignDb.getById(result.id);
+};
+
+describe('Attestation campaign eligibility', () => {
+  beforeAll(async () => {
+    await assetDb.init();
+  });
+
+  afterEach(async () => {
+    while (createdCampaignIds.length) {
+      await attestationCampaignDb.delete(createdCampaignIds.pop());
+    }
+
+    while (createdAssetIds.length) {
+      await assetDb.delete(createdAssetIds.pop());
+    }
+
+    while (createdUserIds.length) {
+      await userDb.delete(createdUserIds.pop());
+    }
+
+    while (createdCompanyIds.length) {
+      await companyDb.delete(createdCompanyIds.pop());
+    }
+  });
+
+  it('omits previously certified returned assets from attestation record details', async () => {
+    const suffix = uniqueSuffix();
+    const admin = await createUser({
+      suffix,
+      role: 'admin',
+      emailPrefix: 'admin-record',
+      firstName: 'Admin',
+      lastName: 'Record'
+    });
+    const employee = await createUser({
+      suffix,
+      emailPrefix: 'employee-record',
+      firstName: 'Erin',
+      lastName: 'Employee'
+    });
+    const company = await createCompany(suffix, 'Record Detail Co');
+
+    const activeAsset = await createAsset({
+      employee_first_name: 'Erin',
+      employee_last_name: 'Employee',
+      employee_email: employee.email,
+      company_id: company.id,
+      asset_type: 'laptop',
+      make: 'Lenovo',
+      model: 'T14',
+      serial_number: `ACTIVE-${suffix}`,
+      asset_tag: `ACTIVE-TAG-${suffix}`,
+      status: 'active'
+    });
+
+    const returnedAsset = await createAsset({
+      employee_first_name: 'Erin',
+      employee_last_name: 'Employee',
+      employee_email: employee.email,
+      company_id: company.id,
+      asset_type: 'monitor',
+      make: 'LG',
+      model: 'UltraFine',
+      serial_number: `RETURNED-${suffix}`,
+      asset_tag: `RETURNED-TAG-${suffix}`,
+      status: 'returned',
+      returned_date: '2026-02-15'
+    });
+
+    const previousCampaign = await createCampaign({
+      name: `Previous Returned ${suffix}`,
+      description: 'Previous certification',
+      start_date: '2026-02-01',
+      status: 'completed',
+      created_by: admin.id
+    });
+    const previousRecord = await attestationRecordDb.create({
+      campaign_id: previousCampaign.id,
+      user_id: employee.id,
+      status: 'completed'
+    });
+    await attestationAssetDb.create({
+      attestation_record_id: previousRecord.id,
+      asset_id: returnedAsset.id,
+      attested_status: 'returned',
+      previous_status: 'active',
+      returned_date: '2026-02-15',
+      notes: 'Already returned',
+      attested_at: '2026-02-05T10:00:00.000Z'
+    });
+
+    const currentCampaign = await createCampaign({
+      name: `Current Returned ${suffix}`,
+      description: 'Current certification',
+      start_date: '2026-03-01',
+      status: 'active',
+      created_by: admin.id
+    });
+    const currentRecord = await attestationRecordDb.create({
+      campaign_id: currentCampaign.id,
+      user_id: employee.id,
+      status: 'pending'
+    });
+
+    const { eligibleAssets } = await getEligibleAssetsForCampaignUser({
+      campaign: currentCampaign,
+      email: employee.email,
+      assetDb,
+      attestationAssetDb,
+      excludeRecordId: currentRecord.id
+    });
+
+    expect(eligibleAssets).toHaveLength(1);
+    expect(eligibleAssets[0].id).toBe(activeAsset.id);
+    expect(eligibleAssets.find((asset) => asset.id === returnedAsset.id)).toBeUndefined();
+  });
+
+  it('counts only eligible users and assets in company-scoped scope preview', async () => {
+    const suffix = uniqueSuffix();
+    const admin = await createUser({
+      suffix,
+      role: 'admin',
+      emailPrefix: 'admin-scope',
+      firstName: 'Admin',
+      lastName: 'Scope'
+    });
+    const eligibleEmployee = await createUser({
+      suffix,
+      emailPrefix: 'eligible-scope',
+      firstName: 'Eli',
+      lastName: 'Eligible'
+    });
+    const excludedEmployee = await createUser({
+      suffix,
+      emailPrefix: 'excluded-scope',
+      firstName: 'Rita',
+      lastName: 'Returned'
+    });
+    const company = await createCompany(suffix, 'Scope Preview Co');
+
+    await createAsset({
+      employee_first_name: 'Eli',
+      employee_last_name: 'Eligible',
+      employee_email: eligibleEmployee.email,
+      company_id: company.id,
+      asset_type: 'laptop',
+      make: 'Dell',
+      model: 'Latitude',
+      serial_number: `SCOPE-ACTIVE-${suffix}`,
+      asset_tag: `SCOPE-ACTIVE-TAG-${suffix}`,
+      status: 'active'
+    });
+
+    const excludedAsset = await createAsset({
+      employee_first_name: 'Rita',
+      employee_last_name: 'Returned',
+      employee_email: excludedEmployee.email,
+      company_id: company.id,
+      asset_type: 'mobile_phone',
+      make: 'Apple',
+      model: 'iPhone',
+      serial_number: `SCOPE-RETURNED-${suffix}`,
+      asset_tag: `SCOPE-RETURNED-TAG-${suffix}`,
+      status: 'returned',
+      returned_date: '2026-02-10'
+    });
+
+    const previousCampaign = await createCampaign({
+      name: `Scope Previous ${suffix}`,
+      description: 'Previous scope certification',
+      start_date: '2026-02-01',
+      status: 'completed',
+      created_by: admin.id
+    });
+    const previousRecord = await attestationRecordDb.create({
+      campaign_id: previousCampaign.id,
+      user_id: excludedEmployee.id,
+      status: 'completed'
+    });
+    await attestationAssetDb.create({
+      attestation_record_id: previousRecord.id,
+      asset_id: excludedAsset.id,
+      attested_status: 'returned',
+      previous_status: 'active',
+      returned_date: '2026-02-10',
+      notes: 'Already certified returned',
+      attested_at: '2026-02-02T10:00:00.000Z'
+    });
+
+    const draftCampaign = await createCampaign({
+      name: `Scope Draft ${suffix}`,
+      description: 'Draft campaign',
+      start_date: '2026-04-01',
+      status: 'draft',
+      target_type: 'companies',
+      target_company_ids: JSON.stringify([company.id]),
+      created_by: admin.id
+    });
+
+    const result = await filterCampaignTargetsByEligibleAssets(
+      draftCampaign,
+      [eligibleEmployee, excludedEmployee],
+      [],
+      { assetDb, attestationAssetDb }
+    );
+
+    expect({
+      registeredUsers: result.eligibleUsers.length,
+      unregisteredOwners: result.eligibleOwners.length,
+      totalEmployees: result.eligibleUsers.length + result.eligibleOwners.length,
+      totalAssets: result.totalEligibleAssets,
+      companiesInScope: result.companiesInScope.size
+    }).toEqual(expect.objectContaining({
+      registeredUsers: 1,
+      unregisteredOwners: 0,
+      totalEmployees: 1,
+      totalAssets: 1,
+      companiesInScope: 1
+    }));
+  });
+
+  it('skips selected targets with no eligible assets when starting a campaign', async () => {
+    const suffix = uniqueSuffix();
+    const admin = await createUser({
+      suffix,
+      role: 'admin',
+      emailPrefix: 'admin-start',
+      firstName: 'Admin',
+      lastName: 'Start'
+    });
+    const eligibleEmployee = await createUser({
+      suffix,
+      emailPrefix: 'eligible-start',
+      firstName: 'Ava',
+      lastName: 'Active'
+    });
+    const excludedEmployee = await createUser({
+      suffix,
+      emailPrefix: 'excluded-start',
+      firstName: 'Rory',
+      lastName: 'Returned'
+    });
+    const company = await createCompany(suffix, 'Start Campaign Co');
+
+    await createAsset({
+      employee_first_name: 'Ava',
+      employee_last_name: 'Active',
+      employee_email: eligibleEmployee.email,
+      company_id: company.id,
+      asset_type: 'laptop',
+      make: 'HP',
+      model: 'EliteBook',
+      serial_number: `START-ACTIVE-${suffix}`,
+      asset_tag: `START-ACTIVE-TAG-${suffix}`,
+      status: 'active'
+    });
+
+    const excludedAsset = await createAsset({
+      employee_first_name: 'Rory',
+      employee_last_name: 'Returned',
+      employee_email: excludedEmployee.email,
+      company_id: company.id,
+      asset_type: 'monitor',
+      make: 'Dell',
+      model: 'U2720Q',
+      serial_number: `START-RETURNED-${suffix}`,
+      asset_tag: `START-RETURNED-TAG-${suffix}`,
+      status: 'returned',
+      returned_date: '2026-01-20'
+    });
+
+    const previousCampaign = await createCampaign({
+      name: `Start Previous ${suffix}`,
+      description: 'Previous selected certification',
+      start_date: '2026-01-01',
+      status: 'completed',
+      created_by: admin.id
+    });
+    const previousRecord = await attestationRecordDb.create({
+      campaign_id: previousCampaign.id,
+      user_id: excludedEmployee.id,
+      status: 'completed'
+    });
+    await attestationAssetDb.create({
+      attestation_record_id: previousRecord.id,
+      asset_id: excludedAsset.id,
+      attested_status: 'returned',
+      previous_status: 'active',
+      returned_date: '2026-01-20',
+      notes: 'Previously certified returned',
+      attested_at: '2026-01-15T10:00:00.000Z'
+    });
+
+    const draftCampaign = await createCampaign({
+      name: `Start Selected ${suffix}`,
+      description: 'Selected target campaign',
+      start_date: '2026-04-10',
+      status: 'draft',
+      target_type: 'selected',
+      target_user_ids: JSON.stringify([eligibleEmployee.id, excludedEmployee.id]),
+      target_emails: JSON.stringify([
+        { email: `invite-no-assets-${suffix}@test.com`, firstName: 'No', lastName: 'Assets' }
+      ]),
+      created_by: admin.id
+    });
+
+    const result = await filterCampaignTargetsByEligibleAssets(
+      draftCampaign,
+      [eligibleEmployee, excludedEmployee],
+      [{ email: `invite-no-assets-${suffix}@test.com`, firstName: 'No', lastName: 'Assets' }],
+      { assetDb, attestationAssetDb }
+    );
+
+    expect(result.eligibleUsers.map((user) => user.id)).toEqual([eligibleEmployee.id]);
+    expect(result.eligibleOwners).toHaveLength(0);
+    expect(result.skippedTargets).toHaveLength(2);
+  });
+
+  it('returns a clear error when every company-scoped target asset is already satisfied', async () => {
+    const suffix = uniqueSuffix();
+    const admin = await createUser({
+      suffix,
+      role: 'admin',
+      emailPrefix: 'admin-empty',
+      firstName: 'Admin',
+      lastName: 'Empty'
+    });
+    const employee = await createUser({
+      suffix,
+      emailPrefix: 'employee-empty',
+      firstName: 'Casey',
+      lastName: 'Closed'
+    });
+    const company = await createCompany(suffix, 'No Eligible Assets Co');
+
+    const excludedAsset = await createAsset({
+      employee_first_name: 'Casey',
+      employee_last_name: 'Closed',
+      employee_email: employee.email,
+      company_id: company.id,
+      asset_type: 'tablet',
+      make: 'Apple',
+      model: 'iPad',
+      serial_number: `EMPTY-RETURNED-${suffix}`,
+      asset_tag: `EMPTY-RETURNED-TAG-${suffix}`,
+      status: 'returned',
+      returned_date: '2026-02-25'
+    });
+
+    const previousCampaign = await createCampaign({
+      name: `Empty Previous ${suffix}`,
+      description: 'Previous completed campaign',
+      start_date: '2026-02-01',
+      status: 'completed',
+      created_by: admin.id
+    });
+    const previousRecord = await attestationRecordDb.create({
+      campaign_id: previousCampaign.id,
+      user_id: employee.id,
+      status: 'completed'
+    });
+    await attestationAssetDb.create({
+      attestation_record_id: previousRecord.id,
+      asset_id: excludedAsset.id,
+      attested_status: 'returned',
+      previous_status: 'active',
+      returned_date: '2026-02-25',
+      notes: 'Already done',
+      attested_at: '2026-02-26T09:00:00.000Z'
+    });
+
+    const draftCampaign = await createCampaign({
+      name: `Empty Draft ${suffix}`,
+      description: 'No eligible assets remain',
+      start_date: '2026-04-15',
+      status: 'draft',
+      target_type: 'companies',
+      target_company_ids: JSON.stringify([company.id]),
+      created_by: admin.id
+    });
+
+    const result = await filterCampaignTargetsByEligibleAssets(
+      draftCampaign,
+      [employee],
+      [],
+      { assetDb, attestationAssetDb }
+    );
+
+    expect(result.eligibleUsers).toHaveLength(0);
+    expect(result.eligibleOwners).toHaveLength(0);
+    expect(result.skippedTargets).toEqual([employee.email]);
+  });
+});

--- a/backend/attestation-history.test.js
+++ b/backend/attestation-history.test.js
@@ -1,0 +1,184 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+
+import {
+  assetDb,
+  attestationAssetDb,
+  attestationCampaignDb,
+  attestationRecordDb,
+  companyDb,
+  userDb
+} from './database.js';
+
+describe('Attestation history defaults', () => {
+  let employeeUser;
+  let company;
+  let historyAsset;
+  let returnedAsset;
+  let previousCampaign;
+  let currentCampaign;
+  let updateCampaign;
+  let previousRecord;
+  let currentRecord;
+  let updateRecord;
+  const timestamp = Date.now();
+
+  beforeAll(async () => {
+    await assetDb.init();
+
+    const employeeEmail = `history-employee-${timestamp}@test.com`;
+
+    await userDb.create({
+      email: employeeEmail,
+      password_hash: 'hash',
+      name: 'History Employee',
+      role: 'employee',
+      first_name: 'History',
+      last_name: 'Employee'
+    });
+    employeeUser = await userDb.getByEmail(employeeEmail);
+
+    company = await companyDb.create({
+      name: `History Co ${timestamp}`,
+      description: 'Attestation history tests'
+    });
+
+    const createdHistoryAsset = await assetDb.create({
+      employee_first_name: 'History',
+      employee_last_name: 'Employee',
+      employee_email: employeeUser.email,
+      company_id: company.id,
+      asset_type: 'Laptop',
+      make: 'Dell',
+      model: 'Latitude',
+      serial_number: `HISTORY-SN-${timestamp}`,
+      asset_tag: `HISTORY-TAG-${timestamp}`,
+      status: 'active'
+    });
+    historyAsset = await assetDb.getById(createdHistoryAsset.id);
+
+    const createdReturnedAsset = await assetDb.create({
+      employee_first_name: 'History',
+      employee_last_name: 'Employee',
+      employee_email: employeeUser.email,
+      company_id: company.id,
+      asset_type: 'Monitor',
+      make: 'LG',
+      model: 'Ultrafine',
+      serial_number: `RETURNED-SN-${timestamp}`,
+      asset_tag: `RETURNED-TAG-${timestamp}`,
+      status: 'returned',
+      returned_date: '2026-01-10'
+    });
+    returnedAsset = await assetDb.getById(createdReturnedAsset.id);
+
+    previousCampaign = await attestationCampaignDb.create({
+      name: `Previous Campaign ${timestamp}`,
+      description: 'Previous monthly certification',
+      start_date: '2026-02-01T00:00:00.000Z',
+      status: 'completed',
+      reminder_days: 7,
+      escalation_days: 10,
+      created_by: employeeUser.id
+    });
+
+    previousRecord = await attestationRecordDb.create({
+      campaign_id: previousCampaign.id,
+      user_id: employeeUser.id,
+      status: 'completed',
+      started_at: '2026-02-05T10:00:00.000Z',
+      completed_at: '2026-02-05T10:15:00.000Z'
+    });
+
+    await attestationAssetDb.create({
+      attestation_record_id: previousRecord.id,
+      asset_id: historyAsset.id,
+      attested_status: 'returned',
+      previous_status: 'active',
+      returned_date: '2026-02-15',
+      notes: 'Returned during February certification',
+      attested_at: '2026-02-05T10:05:00.000Z'
+    });
+
+    currentCampaign = await attestationCampaignDb.create({
+      name: `Current Campaign ${timestamp}`,
+      description: 'Current monthly certification',
+      start_date: '2026-03-01T00:00:00.000Z',
+      status: 'active',
+      reminder_days: 7,
+      escalation_days: 10,
+      created_by: employeeUser.id
+    });
+
+    currentRecord = await attestationRecordDb.create({
+      campaign_id: currentCampaign.id,
+      user_id: employeeUser.id,
+      status: 'pending'
+    });
+
+    updateCampaign = await attestationCampaignDb.create({
+      name: `Update Campaign ${timestamp}`,
+      description: 'Update returned date test',
+      start_date: '2026-04-01T00:00:00.000Z',
+      status: 'active',
+      reminder_days: 7,
+      escalation_days: 10,
+      created_by: employeeUser.id
+    });
+
+    updateRecord = await attestationRecordDb.create({
+      campaign_id: updateCampaign.id,
+      user_id: employeeUser.id,
+      status: 'pending'
+    });
+  });
+
+  afterAll(async () => {
+    if (updateCampaign?.id) await attestationCampaignDb.delete(updateCampaign.id);
+    if (currentCampaign?.id) await attestationCampaignDb.delete(currentCampaign.id);
+    if (previousCampaign?.id) await attestationCampaignDb.delete(previousCampaign.id);
+    if (historyAsset?.id) await assetDb.delete(historyAsset.id);
+    if (returnedAsset?.id) await assetDb.delete(returnedAsset.id);
+    if (employeeUser?.id) await userDb.delete(employeeUser.id);
+    if (company?.id) await companyDb.delete(company.id);
+  });
+
+  it('returns the latest certification result for an asset when excluding the current record', async () => {
+    const lastCertification = await attestationAssetDb.getLatestByAssetId(historyAsset.id, currentRecord.id);
+
+    expect(lastCertification).toEqual(expect.objectContaining({
+      asset_id: historyAsset.id,
+      attested_status: 'returned',
+      returned_date: '2026-02-15'
+    }));
+  });
+
+  it('persists returned_date on the attestation record and updates the live asset when status stays returned', async () => {
+    await attestationAssetDb.create({
+      attestation_record_id: updateRecord.id,
+      asset_id: returnedAsset.id,
+      attested_status: 'returned',
+      previous_status: returnedAsset.status,
+      returned_date: '2026-02-20',
+      notes: 'Confirmed returned again',
+      attested_at: '2026-04-05T10:05:00.000Z'
+    });
+    await attestationRecordDb.update(updateRecord.id, {
+      status: 'in_progress',
+      started_at: '2026-04-05T10:00:00.000Z'
+    });
+    await assetDb.updateStatus(returnedAsset.id, 'returned', 'Confirmed returned again', '2026-02-20');
+
+    const attestedAssets = await attestationAssetDb.getByRecordId(updateRecord.id);
+    const persistedAttestation = attestedAssets.find(({ asset_id }) => asset_id === returnedAsset.id);
+    const refreshedAsset = await assetDb.getById(returnedAsset.id);
+    const refreshedRecord = await attestationRecordDb.getById(updateRecord.id);
+
+    expect(persistedAttestation).toEqual(expect.objectContaining({
+      asset_id: returnedAsset.id,
+      attested_status: 'returned',
+      returned_date: '2026-02-20'
+    }));
+    expect(refreshedAsset.returned_date).toBe('2026-02-20');
+    expect(refreshedRecord.status).toBe('in_progress');
+  });
+});

--- a/backend/database.js
+++ b/backend/database.js
@@ -2521,32 +2521,58 @@ export const assetDb = {
   },
   update: async (id, asset) => {
     const now = new Date().toISOString();
+    const existingAsset = await assetDb.getById(id);
+
+    if (!existingAsset) {
+      throw new Error(`Asset not found: ${id}`);
+    }
+
+    const hasOwn = (field) => Object.prototype.hasOwnProperty.call(asset, field);
+    const mergedAsset = {
+      employee_first_name: hasOwn('employee_first_name') ? asset.employee_first_name : existingAsset.employee_first_name,
+      employee_last_name: hasOwn('employee_last_name') ? asset.employee_last_name : existingAsset.employee_last_name,
+      employee_email: hasOwn('employee_email') ? asset.employee_email : existingAsset.employee_email,
+      manager_first_name: hasOwn('manager_first_name') ? asset.manager_first_name : existingAsset.manager_first_name,
+      manager_last_name: hasOwn('manager_last_name') ? asset.manager_last_name : existingAsset.manager_last_name,
+      manager_email: hasOwn('manager_email') ? asset.manager_email : existingAsset.manager_email,
+      company_name: hasOwn('company_name') ? asset.company_name : existingAsset.company_name,
+      company_id: hasOwn('company_id') ? asset.company_id : existingAsset.company_id,
+      asset_type: hasOwn('asset_type') ? asset.asset_type : existingAsset.asset_type,
+      make: hasOwn('make') ? asset.make : existingAsset.make,
+      model: hasOwn('model') ? asset.model : existingAsset.model,
+      serial_number: hasOwn('serial_number') ? asset.serial_number : existingAsset.serial_number,
+      asset_tag: hasOwn('asset_tag') ? asset.asset_tag : existingAsset.asset_tag,
+      status: hasOwn('status') ? asset.status : existingAsset.status,
+      issued_date: hasOwn('issued_date') ? asset.issued_date : existingAsset.issued_date,
+      returned_date: hasOwn('returned_date') ? asset.returned_date : existingAsset.returned_date,
+      notes: hasOwn('notes') ? asset.notes : existingAsset.notes
+    };
 
     // Look up owner_id from employee_email
     let ownerId = null;
-    if (asset.employee_email) {
-      const owner = await dbGet('SELECT id FROM users WHERE LOWER(email) = LOWER(?)', [asset.employee_email]);
+    if (mergedAsset.employee_email) {
+      const owner = await dbGet('SELECT id FROM users WHERE LOWER(email) = LOWER(?)', [mergedAsset.employee_email]);
       ownerId = owner?.id || null;
     }
 
     // Look up manager_id from manager_email
     let managerId = null;
-    if (asset.manager_email) {
-      const manager = await dbGet('SELECT id FROM users WHERE LOWER(email) = LOWER(?)', [asset.manager_email]);
+    if (mergedAsset.manager_email) {
+      const manager = await dbGet('SELECT id FROM users WHERE LOWER(email) = LOWER(?)', [mergedAsset.manager_email]);
       managerId = manager?.id || null;
     }
 
     // Look up company_id from company_name (preferred) or use provided company_id
     // company_name takes precedence since the frontend sends the user-selected name
     let companyId = null;
-    if (asset.company_name) {
-      const company = await dbGet('SELECT id FROM companies WHERE name = ?', [asset.company_name]);
+    if (mergedAsset.company_name) {
+      const company = await dbGet('SELECT id FROM companies WHERE name = ?', [mergedAsset.company_name]);
       if (!company) {
-        throw new Error(`Company not found: ${asset.company_name}`);
+        throw new Error(`Company not found: ${mergedAsset.company_name}`);
       }
       companyId = company.id;
     } else {
-      companyId = asset.company_id || null;
+      companyId = mergedAsset.company_id || null;
     }
     if (!companyId) {
       throw new Error('Company is required');
@@ -2562,25 +2588,25 @@ export const assetDb = {
           status = ?, issued_date = ?, returned_date = ?, last_updated = ?, notes = ?
       WHERE id = ?
     `, [
-      asset.employee_first_name || '', // stored for unregistered users
-      asset.employee_last_name || '', // stored for unregistered users
-      asset.employee_email || '', // keep email for backward compat lookups
+      mergedAsset.employee_first_name || '', // stored for unregistered users
+      mergedAsset.employee_last_name || '', // stored for unregistered users
+      mergedAsset.employee_email || '', // keep email for backward compat lookups
       ownerId,
-      asset.manager_first_name || '', // stored for unregistered managers
-      asset.manager_last_name || '', // stored for unregistered managers
-      asset.manager_email || '', // keep email for backward compat lookups
+      mergedAsset.manager_first_name || '', // stored for unregistered managers
+      mergedAsset.manager_last_name || '', // stored for unregistered managers
+      mergedAsset.manager_email || '', // keep email for backward compat lookups
       managerId,
       companyId,
-      asset.asset_type,
-      asset.make || '',
-      asset.model || '',
-      asset.serial_number,
-      asset.asset_tag || null,
-      asset.status,
-      asset.issued_date || null,
-      asset.returned_date || null,
+      mergedAsset.asset_type,
+      mergedAsset.make || '',
+      mergedAsset.model || '',
+      mergedAsset.serial_number,
+      mergedAsset.asset_tag || null,
+      mergedAsset.status,
+      mergedAsset.issued_date || null,
+      mergedAsset.returned_date || null,
       now,
-      asset.notes || '',
+      mergedAsset.notes || '',
       id
     ]);
   },

--- a/backend/database.js
+++ b/backend/database.js
@@ -1148,6 +1148,7 @@ const initDb = async () => {
       asset_id INTEGER NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
       attested_status TEXT,
       previous_status TEXT,
+      returned_date TIMESTAMP,
       notes TEXT,
       attested_at TIMESTAMP
     )
@@ -1158,6 +1159,7 @@ const initDb = async () => {
       asset_id INTEGER NOT NULL,
       attested_status TEXT,
       previous_status TEXT,
+      returned_date TEXT,
       notes TEXT,
       attested_at TEXT,
       FOREIGN KEY(attestation_record_id) REFERENCES attestation_records(id) ON DELETE CASCADE,
@@ -1691,6 +1693,27 @@ const initDb = async () => {
     }
   } catch (err) {
     console.error('Migration error (attestation_new_assets status column):', err.message);
+    // Don't fail initialization
+  }
+
+  // Migration: Add returned_date column to attestation_assets table
+  try {
+    const attestationAssetCols = isPostgres
+      ? await dbAll(`
+          SELECT column_name as name
+          FROM information_schema.columns
+          WHERE table_name = 'attestation_assets'
+        `)
+      : await dbAll("PRAGMA table_info(attestation_assets)");
+
+    const hasReturnedDate = attestationAssetCols.some(col => col.name === 'returned_date');
+    if (!hasReturnedDate) {
+      console.log('Migrating attestation_assets table: adding returned_date column...');
+      await dbRun("ALTER TABLE attestation_assets ADD COLUMN returned_date " + (isPostgres ? "TIMESTAMP" : "TEXT"));
+      console.log('Migration complete: Added returned_date column to attestation_assets');
+    }
+  } catch (err) {
+    console.error('Migration error (attestation_assets returned_date column):', err.message);
     // Don't fail initialization
   }
 
@@ -4476,27 +4499,62 @@ export const attestationAssetDb = {
   create: async (asset) => {
     if (isPostgres) {
       const result = await dbRun(
-        `INSERT INTO attestation_assets (attestation_record_id, asset_id, attested_status, previous_status, notes, attested_at)
-         VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-        [asset.attestation_record_id, asset.asset_id, asset.attested_status, asset.previous_status, asset.notes, asset.attested_at]
+        `INSERT INTO attestation_assets (attestation_record_id, asset_id, attested_status, previous_status, returned_date, notes, attested_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+        [asset.attestation_record_id, asset.asset_id, asset.attested_status, asset.previous_status, asset.returned_date || null, asset.notes, asset.attested_at]
       );
       return { id: result.rows[0].id };
     } else {
       const result = await dbRun(
-        `INSERT INTO attestation_assets (attestation_record_id, asset_id, attested_status, previous_status, notes, attested_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [asset.attestation_record_id, asset.asset_id, asset.attested_status, asset.previous_status, asset.notes, asset.attested_at]
+        `INSERT INTO attestation_assets (attestation_record_id, asset_id, attested_status, previous_status, returned_date, notes, attested_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [asset.attestation_record_id, asset.asset_id, asset.attested_status, asset.previous_status, asset.returned_date || null, asset.notes, asset.attested_at]
       );
       return { id: result.lastInsertRowid };
     }
   },
 
   getByRecordId: async (recordId) => {
-    const assets = await dbAll('SELECT * FROM attestation_assets WHERE attestation_record_id = ?', [recordId]);
+    const assets = await dbAll(
+      'SELECT * FROM attestation_assets WHERE attestation_record_id = ? ORDER BY attested_at DESC, id DESC',
+      [recordId]
+    );
     return assets.map(a => ({
       ...a,
+      returned_date: normalizeDateOnly(a.returned_date),
       attested_at: normalizeDates(a.attested_at)
     }));
+  },
+
+  getLatestByAssetId: async (assetId, excludeRecordId = null) => {
+    const params = [assetId];
+    let query = `
+      SELECT aa.*
+      FROM attestation_assets aa
+      WHERE aa.asset_id = ?
+    `;
+
+    if (excludeRecordId !== null && excludeRecordId !== undefined) {
+      query += ` AND aa.attestation_record_id != ${isPostgres ? '$2' : '?'}`;
+      params.push(excludeRecordId);
+    }
+
+    query += `
+      ORDER BY aa.attested_at DESC, aa.id DESC
+      LIMIT 1
+    `;
+
+    const asset = await dbGet(query, params);
+
+    if (!asset) {
+      return null;
+    }
+
+    return {
+      ...asset,
+      returned_date: normalizeDateOnly(asset.returned_date),
+      attested_at: normalizeDates(asset.attested_at)
+    };
   },
 
   update: async (id, updates) => {
@@ -4506,6 +4564,10 @@ export const attestationAssetDb = {
     if (updates.attested_status !== undefined) {
       fields.push(isPostgres ? `attested_status = $${fields.length + 1}` : 'attested_status = ?');
       params.push(updates.attested_status);
+    }
+    if (updates.returned_date !== undefined) {
+      fields.push(isPostgres ? `returned_date = $${fields.length + 1}` : 'returned_date = ?');
+      params.push(updates.returned_date);
     }
     if (updates.notes !== undefined) {
       fields.push(isPostgres ? `notes = $${fields.length + 1}` : 'notes = ?');
@@ -4953,4 +5015,3 @@ export const dangerZoneDb = {
 };
 
 export default { databaseEngine };
-

--- a/backend/database.js
+++ b/backend/database.js
@@ -2565,12 +2565,14 @@ export const assetDb = {
     // Look up company_id from company_name (preferred) or use provided company_id
     // company_name takes precedence since the frontend sends the user-selected name
     let companyId = null;
-    if (mergedAsset.company_name) {
+    if (hasOwn('company_name') && mergedAsset.company_name) {
       const company = await dbGet('SELECT id FROM companies WHERE name = ?', [mergedAsset.company_name]);
       if (!company) {
         throw new Error(`Company not found: ${mergedAsset.company_name}`);
       }
       companyId = company.id;
+    } else if (hasOwn('company_id')) {
+      companyId = mergedAsset.company_id || null;
     } else {
       companyId = mergedAsset.company_id || null;
     }

--- a/backend/routes/attestation.js
+++ b/backend/routes/attestation.js
@@ -23,6 +23,145 @@ const sanitizeForLog = (text, maxLength = 500) => {
   return text.replace(/[\r\n]/g, ' ').substring(0, maxLength);
 };
 
+export const getCampaignCompanyIds = (campaign) => {
+  if (campaign.target_type !== 'companies' || !campaign.target_company_ids) {
+    return null;
+  }
+
+  return JSON.parse(campaign.target_company_ids)
+    .map((id) => Number(id))
+    .filter((id) => Number.isInteger(id) && id > 0);
+};
+
+export const shouldExcludeAssetFromFutureAttestations = (asset) => (
+  asset.status === 'returned' && asset.last_certification_result?.attested_status === 'returned'
+);
+
+export const getAssetsWithCertificationHistory = async (assets, attestationAssetDb, excludeRecordId = null) => {
+  const latestCertificationResults = await Promise.all(
+    assets.map(async (asset) => {
+      const lastCertification = await attestationAssetDb.getLatestByAssetId(asset.id, excludeRecordId);
+      return [asset.id, lastCertification];
+    })
+  );
+
+  const latestCertificationByAssetId = new Map(latestCertificationResults);
+  return assets.map((asset) => ({
+    ...asset,
+    last_certification_result: latestCertificationByAssetId.get(asset.id) || null
+  }));
+};
+
+export const getEligibleAssetsForCampaignUser = async ({
+  campaign,
+  email,
+  assetDb,
+  attestationAssetDb,
+  excludeRecordId = null,
+  companyIds = undefined
+}) => {
+  const scopedCompanyIds = companyIds === undefined ? getCampaignCompanyIds(campaign) : companyIds;
+  const allAssets = await assetDb.getByEmployeeEmail(email);
+  const scopedAssets = scopedCompanyIds
+    ? allAssets.filter((asset) => scopedCompanyIds.includes(asset.company_id))
+    : allAssets;
+  const assetsWithHistory = await getAssetsWithCertificationHistory(scopedAssets, attestationAssetDb, excludeRecordId);
+  const eligibleAssets = assetsWithHistory.filter((asset) => !shouldExcludeAssetFromFutureAttestations(asset));
+
+  return {
+    assetsWithHistory,
+    eligibleAssets
+  };
+};
+
+export const normalizePendingInviteTarget = (target, assetCount) => ({
+  ...target,
+  employee_email: target.employee_email || target.email,
+  employee_first_name: target.employee_first_name ?? target.firstName ?? '',
+  employee_last_name: target.employee_last_name ?? target.lastName ?? '',
+  asset_count: assetCount
+});
+
+export const filterCampaignTargetsByEligibleAssets = async (campaign, users, unregisteredOwners, deps) => {
+  const {
+    assetDb,
+    attestationAssetDb
+  } = deps;
+
+  const companyIds = getCampaignCompanyIds(campaign);
+  const handledEmails = new Set();
+  const eligibleUsers = [];
+  const eligibleOwners = [];
+  const companiesInScope = new Set();
+  const skippedTargets = [];
+  let totalEligibleAssets = 0;
+
+  for (const user of users) {
+    const normalizedEmail = user.email?.toLowerCase();
+    if (!normalizedEmail || handledEmails.has(normalizedEmail)) {
+      continue;
+    }
+
+    const { eligibleAssets } = await getEligibleAssetsForCampaignUser({
+      campaign,
+      email: user.email,
+      assetDb,
+      attestationAssetDb,
+      companyIds
+    });
+
+    if (eligibleAssets.length === 0) {
+      skippedTargets.push(user.email);
+      handledEmails.add(normalizedEmail);
+      continue;
+    }
+
+    eligibleUsers.push(user);
+    totalEligibleAssets += eligibleAssets.length;
+    eligibleAssets.forEach((asset) => {
+      if (asset.company_id) companiesInScope.add(asset.company_id);
+    });
+    handledEmails.add(normalizedEmail);
+  }
+
+  for (const owner of unregisteredOwners) {
+    const ownerEmail = owner.employee_email || owner.email;
+    const normalizedEmail = ownerEmail?.toLowerCase();
+    if (!normalizedEmail || handledEmails.has(normalizedEmail)) {
+      continue;
+    }
+
+    const { eligibleAssets } = await getEligibleAssetsForCampaignUser({
+      campaign,
+      email: ownerEmail,
+      assetDb,
+      attestationAssetDb,
+      companyIds
+    });
+
+    if (eligibleAssets.length === 0) {
+      skippedTargets.push(ownerEmail);
+      handledEmails.add(normalizedEmail);
+      continue;
+    }
+
+    eligibleOwners.push(normalizePendingInviteTarget(owner, eligibleAssets.length));
+    totalEligibleAssets += eligibleAssets.length;
+    eligibleAssets.forEach((asset) => {
+      if (asset.company_id) companiesInScope.add(asset.company_id);
+    });
+    handledEmails.add(normalizedEmail);
+  }
+
+  return {
+    eligibleUsers,
+    eligibleOwners,
+    totalEligibleAssets,
+    companiesInScope,
+    skippedTargets
+  };
+};
+
 /**
  * Create and configure the attestation router
  * @param {Object} deps - Dependencies
@@ -229,8 +368,6 @@ export default function createAttestationRouter(deps) {
 
       let registeredUsers = [];
       let unregisteredOwners = [];
-      let totalAssets = 0;
-      const scopeCompanyIds = new Set();
 
       if (campaign.target_type === 'companies' && campaign.target_company_ids) {
         const companyIds = JSON.parse(campaign.target_company_ids);
@@ -239,37 +376,22 @@ export default function createAttestationRouter(deps) {
 
         registeredUsers = await assetDb.getRegisteredOwnersByCompanyIds(validCompanyIds);
         unregisteredOwners = await assetDb.getUnregisteredOwnersByCompanyIds(validCompanyIds);
-
-        for (const cId of validCompanyIds) {
-          const count = await companyDb.getAssetCount(cId);
-          totalAssets += count;
-          scopeCompanyIds.add(cId);
-        }
       } else if (campaign.target_type === 'selected') {
         // Handle selected users
         if (campaign.target_user_ids) {
           const targetIds = JSON.parse(campaign.target_user_ids);
           const allUsers = await userDb.getAll();
           registeredUsers = allUsers.filter(u => targetIds.includes(u.id));
-
-          for (const user of registeredUsers) {
-            const assets = await assetDb.getByEmployeeEmail(user.email);
-            totalAssets += assets.length;
-            assets.forEach(a => { if (a.company_id) scopeCompanyIds.add(a.company_id); });
-          }
         }
 
         // Handle selected emails (unregistered or explicit invites)
         if (campaign.target_emails) {
           const targetEmails = JSON.parse(campaign.target_emails);
           // These are treated as unregistered invites. 
-          // We can check if they have assets to provide better stats
           for (const target of targetEmails) {
             const assets = await assetDb.getByEmployeeEmail(target.email);
             if (assets.length > 0) {
               unregisteredOwners.push({ ...target, asset_count: assets.length });
-              totalAssets += assets.length;
-              assets.forEach(a => { if (a.company_id) scopeCompanyIds.add(a.company_id); });
             } else {
               // Invited person with 0 assets
               unregisteredOwners.push({ ...target, asset_count: 0 });
@@ -280,19 +402,26 @@ export default function createAttestationRouter(deps) {
         // 'all' mode
         registeredUsers = await userDb.getAll();
         unregisteredOwners = await assetDb.getUnregisteredOwners();
-        const allAssets = await assetDb.getAll();
-        totalAssets = allAssets.length;
-        allAssets.forEach(a => { if (a.company_id) scopeCompanyIds.add(a.company_id); });
       }
+
+      const {
+        eligibleUsers,
+        eligibleOwners,
+        totalEligibleAssets,
+        companiesInScope
+      } = await filterCampaignTargetsByEligibleAssets(campaign, registeredUsers, unregisteredOwners, {
+        assetDb,
+        attestationAssetDb
+      });
 
       res.json({
         success: true,
         scope: {
-          registeredUsers: registeredUsers.length,
-          unregisteredOwners: unregisteredOwners.length,
-          totalEmployees: registeredUsers.length + unregisteredOwners.length,
-          totalAssets,
-          companiesInScope: scopeCompanyIds.size,
+          registeredUsers: eligibleUsers.length,
+          unregisteredOwners: eligibleOwners.length,
+          totalEmployees: eligibleUsers.length + eligibleOwners.length,
+          totalAssets: totalEligibleAssets,
+          companiesInScope: companiesInScope.size,
           targetType: campaign.target_type
         }
       });
@@ -362,8 +491,6 @@ export default function createAttestationRouter(deps) {
       // Get users based on targeting
       let users = [];
       let unregisteredOwners = [];
-      // Set to track emails we've already handled (to avoid duplicates between lists)
-      const handledEmails = new Set();
 
       if (campaign.target_type === 'companies' && campaign.target_company_ids) {
         try {
@@ -382,10 +509,6 @@ export default function createAttestationRouter(deps) {
 
           // Get unregistered owners by company IDs
           unregisteredOwners = await assetDb.getUnregisteredOwnersByCompanyIds(validCompanyIds);
-
-          if (users.length === 0 && unregisteredOwners.length === 0) {
-            return res.status(400).json({ error: 'No asset owners found in the selected companies' });
-          }
         } catch (parseError) {
           logger.error({ err: parseError, userId: req.user?.id }, 'Error parsing target_company_ids');
           return res.status(500).json({ error: 'Invalid target company IDs format' });
@@ -453,20 +576,30 @@ export default function createAttestationRouter(deps) {
         unregisteredOwners = await assetDb.getUnregisteredOwners();
       }
 
+      const {
+        eligibleUsers,
+        eligibleOwners,
+        skippedTargets
+      } = await filterCampaignTargetsByEligibleAssets(campaign, users, unregisteredOwners, {
+        assetDb,
+        attestationAssetDb
+      });
+
+      if (eligibleUsers.length === 0 && eligibleOwners.length === 0) {
+        return res.status(400).json({ error: 'No eligible assets found for the selected campaign targets' });
+      }
+
       // Create attestation records for registered users
       let recordsCreated = 0;
       let emailsSent = 0;
 
-      for (const user of users) {
-        if (handledEmails.has(user.email.toLowerCase())) continue;
-
+      for (const user of eligibleUsers) {
         await attestationRecordDb.create({
           campaign_id: campaign.id,
           user_id: user.id,
           status: 'pending'
         });
         recordsCreated++;
-        handledEmails.add(user.email.toLowerCase());
 
         // Send email notification
         if (user.email) {
@@ -490,9 +623,7 @@ export default function createAttestationRouter(deps) {
       const ssoEnabled = oidcSettings?.enabled || false;
       const ssoButtonText = oidcSettings?.button_text || 'Sign In with SSO';
 
-      for (const owner of unregisteredOwners) {
-        if (handledEmails.has(owner.employee_email.toLowerCase())) continue;
-
+      for (const owner of eligibleOwners) {
         const crypto = await import('crypto');
         const inviteToken = crypto.randomBytes(32).toString('hex');
 
@@ -505,7 +636,6 @@ export default function createAttestationRouter(deps) {
           invite_sent_at: new Date().toISOString()
         });
         pendingInvitesCreated++;
-        handledEmails.add(owner.employee_email.toLowerCase());
 
         try {
           const { sendAttestationRegistrationInvite } = await import('../services/smtpMailer.js');
@@ -538,7 +668,7 @@ export default function createAttestationRouter(deps) {
         'attestation_campaign',
         campaign.id,
         campaign.name,
-        `Started attestation campaign: ${campaign.name} (targeting: ${campaign.target_type}). Created ${recordsCreated} records, sent ${emailsSent} emails. Created ${pendingInvitesCreated} pending invites, sent ${inviteEmailsSent} invite emails`,
+        `Started attestation campaign: ${campaign.name} (targeting: ${campaign.target_type}). Created ${recordsCreated} records, sent ${emailsSent} emails. Created ${pendingInvitesCreated} pending invites, sent ${inviteEmailsSent} invite emails. Skipped ${skippedTargets.length} targets with no eligible assets.`,
         req.user.email
       );
 
@@ -548,7 +678,8 @@ export default function createAttestationRouter(deps) {
         recordsCreated,
         emailsSent,
         pendingInvitesCreated,
-        inviteEmailsSent
+        inviteEmailsSent,
+        skippedTargets: skippedTargets.length
       });
     } catch (error) {
       logger.error({ err: error, userId: req.user?.id }, 'Error starting campaign');
@@ -820,41 +951,29 @@ export default function createAttestationRouter(deps) {
       }
 
       const campaign = await attestationCampaignDb.getById(record.campaign_id);
+      const recordUser = await userDb.getById(record.user_id);
 
-      // Get user's assets
-      const allAssets = await assetDb.getAll();
-      let userAssets = allAssets.filter(a => a.employee_email === req.user.email);
-
-      // Filter by company if campaign is company-scoped
-      if (campaign.target_type === 'companies' && campaign.target_company_ids) {
-        try {
-          const targetCompanyIds = JSON.parse(campaign.target_company_ids);
-          userAssets = userAssets.filter(asset => targetCompanyIds.includes(asset.company_id));
-        } catch (parseError) {
-          logger.error({ err: parseError, userId: req.user?.id }, 'Error parsing target_company_ids');
-        }
+      if (!recordUser) {
+        return res.status(404).json({ error: 'Attestation user not found' });
       }
 
-      const attestedAssets = await attestationAssetDb.getByRecordId(record.id);
+      const { eligibleAssets } = await getEligibleAssetsForCampaignUser({
+        campaign,
+        email: recordUser.email,
+        assetDb,
+        attestationAssetDb,
+        excludeRecordId: record.id
+      });
+      const eligibleAssetIds = new Set(eligibleAssets.map((asset) => asset.id));
+      const attestedAssets = (await attestationAssetDb.getByRecordId(record.id))
+        .filter((asset) => eligibleAssetIds.has(asset.asset_id));
       const newAssets = await attestationNewAssetDb.getByRecordId(record.id);
-      const latestCertificationResults = await Promise.all(
-        userAssets.map(async (asset) => {
-          const lastCertification = await attestationAssetDb.getLatestByAssetId(asset.id, record.id);
-          return [asset.id, lastCertification];
-        })
-      );
-      const latestCertificationByAssetId = new Map(latestCertificationResults);
-
-      const assetsWithCertificationHistory = userAssets.map(asset => ({
-        ...asset,
-        last_certification_result: latestCertificationByAssetId.get(asset.id) || null
-      }));
 
       res.json({
         success: true,
         record,
         campaign,
-        assets: assetsWithCertificationHistory,
+        assets: eligibleAssets,
         attestedAssets,
         newAssets
       });

--- a/backend/routes/attestation.js
+++ b/backend/routes/attestation.js
@@ -837,12 +837,24 @@ export default function createAttestationRouter(deps) {
 
       const attestedAssets = await attestationAssetDb.getByRecordId(record.id);
       const newAssets = await attestationNewAssetDb.getByRecordId(record.id);
+      const latestCertificationResults = await Promise.all(
+        userAssets.map(async (asset) => {
+          const lastCertification = await attestationAssetDb.getLatestByAssetId(asset.id, record.id);
+          return [asset.id, lastCertification];
+        })
+      );
+      const latestCertificationByAssetId = new Map(latestCertificationResults);
+
+      const assetsWithCertificationHistory = userAssets.map(asset => ({
+        ...asset,
+        last_certification_result: latestCertificationByAssetId.get(asset.id) || null
+      }));
 
       res.json({
         success: true,
         record,
         campaign,
-        assets: userAssets,
+        assets: assetsWithCertificationHistory,
         attestedAssets,
         newAssets
       });
@@ -867,6 +879,7 @@ export default function createAttestationRouter(deps) {
 
       const { attested_status, notes, returned_date } = req.body;
       const asset = await assetDb.getById(req.params.assetId);
+      const normalizedReturnedDate = attested_status === 'returned' ? sanitizeDateValue(returned_date) : null;
 
       if (!asset) {
         return res.status(404).json({ error: 'Asset not found' });
@@ -877,6 +890,7 @@ export default function createAttestationRouter(deps) {
         asset_id: asset.id,
         attested_status,
         previous_status: asset.status,
+        returned_date: normalizedReturnedDate,
         notes,
         attested_at: new Date().toISOString()
       });
@@ -889,11 +903,11 @@ export default function createAttestationRouter(deps) {
         });
       }
 
-      // If attested_status changed, update the asset
-      if (attested_status && attested_status !== asset.status) {
-        // Pass returned_date if status is 'returned'
-        const returnedDateValue = attested_status === 'returned' ? returned_date : null;
-        await assetDb.updateStatus(asset.id, attested_status, notes, returnedDateValue);
+      const shouldUpdateReturnedDate = attested_status === 'returned' && asset.returned_date !== normalizedReturnedDate;
+
+      // Keep the live asset row aligned with the latest attestation details.
+      if ((attested_status && attested_status !== asset.status) || shouldUpdateReturnedDate) {
+        await assetDb.updateStatus(asset.id, attested_status, notes, normalizedReturnedDate);
 
         await auditDb.log(
           'update',

--- a/backend/types/database.d.ts
+++ b/backend/types/database.d.ts
@@ -304,6 +304,7 @@ export interface AttestationRecordDb {
 export interface AttestationAssetDb {
   create(asset: Record<string, unknown>): Promise<{ id: number }>;
   getByRecordId(recordId: number): Promise<Array<Record<string, unknown>>>;
+  getLatestByAssetId(assetId: number, excludeRecordId?: number | null): Promise<Record<string, unknown> | null>;
   update(id: number, updates: Record<string, unknown>): Promise<void>;
 }
 

--- a/frontend/src/components/AssetEditModal.test.jsx
+++ b/frontend/src/components/AssetEditModal.test.jsx
@@ -289,6 +289,64 @@ describe('AssetEditModal Component', () => {
     });
   });
 
+  it('passes the saved asset with preserved employee names back to the parent for employee self-edits', async () => {
+    const user = userEvent.setup();
+    mockUser = { role: 'employee', email: 'john@example.com' };
+    const currentUser = { roles: ['user'] };
+
+    const mockResponse = {
+      asset: {
+        ...sampleAsset,
+        make: 'Framework',
+        model: '13',
+        employee_first_name: 'John',
+        employee_last_name: 'Doe'
+      }
+    };
+
+    global.fetch.mockImplementation((url, options) => {
+      if (url === '/api/companies/names') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'Acme Corp' }],
+        });
+      }
+      if (url === '/api/asset-types') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'laptop', display_name: 'Laptop' }],
+        });
+      }
+      if (url === '/api/assets/1' && options?.method === 'PUT') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockResponse,
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <AssetEditModal
+        asset={sampleAsset}
+        currentUser={currentUser}
+        onClose={mockOnClose}
+        onSaved={mockOnSaved}
+      />
+    );
+
+    await user.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(mockOnSaved).toHaveBeenCalledWith(expect.objectContaining({
+        employee_first_name: 'John',
+        employee_last_name: 'Doe',
+        make: 'Framework',
+        model: '13'
+      }));
+    });
+  });
+
   it('has status dropdown with backend-compatible values', () => {
     const currentUser = { roles: ['admin'] };
 

--- a/frontend/src/pages/MyAttestationsPage.jsx
+++ b/frontend/src/pages/MyAttestationsPage.jsx
@@ -44,6 +44,33 @@ import { DatePicker } from '@/components/ui/date-picker';
 import CompanyCombobox from '@/components/CompanyCombobox';
 import UserAttestationTable from '@/components/UserAttestationTable';
 
+const getLatestAttestedAssetsById = (attestedAssets = []) => {
+  return attestedAssets.reduce((acc, attestedAsset) => {
+    if (!acc[attestedAsset.asset_id]) {
+      acc[attestedAsset.asset_id] = attestedAsset;
+    }
+    return acc;
+  }, {});
+};
+
+const getInitialStatusForAsset = (asset, currentAttestation) => {
+  return currentAttestation?.attested_status
+    || asset.last_certification_result?.attested_status
+    || asset.status;
+};
+
+const getInitialReturnedDateForAsset = (asset, currentAttestation, status) => {
+  if (currentAttestation?.returned_date) {
+    return currentAttestation.returned_date;
+  }
+
+  if (status !== 'returned') {
+    return '';
+  }
+
+  return asset.last_certification_result?.returned_date || asset.returned_date || '';
+};
+
 export default function MyAttestationsPage() {
   const { getAuthHeaders, user } = useAuth();
   const { toast } = useToast();
@@ -193,12 +220,21 @@ export default function MyAttestationsPage() {
       // to avoid requiring users to re-certify assets they've already confirmed
       setCertifiedAssetIds(attestedIds);
 
-      // Initialize selected statuses with current asset statuses
+      const currentAttestationsByAssetId = getLatestAttestedAssetsById(data.attestedAssets);
       const statuses = {};
+      const dates = {};
       data.assets?.forEach(asset => {
-        statuses[asset.id] = asset.status;
+        const currentAttestation = currentAttestationsByAssetId[asset.id];
+        const initialStatus = getInitialStatusForAsset(asset, currentAttestation);
+        const initialReturnedDate = getInitialReturnedDateForAsset(asset, currentAttestation, initialStatus);
+
+        statuses[asset.id] = initialStatus;
+        if (initialReturnedDate) {
+          dates[asset.id] = initialReturnedDate;
+        }
       });
       setSelectedStatuses(statuses);
+      setReturnedDates(dates);
     } catch (err) {
       console.error(err);
       toast({
@@ -355,6 +391,7 @@ export default function MyAttestationsPage() {
       setShowAttestationModal(false);
       setCertifiedAssetIds(new Set());
       setSelectedStatuses({});
+      setReturnedDates({});
       loadAttestations();
     } catch (err) {
       console.error(err);
@@ -379,6 +416,8 @@ export default function MyAttestationsPage() {
       </div>
     );
   }
+
+  const currentAttestationsByAssetId = getLatestAttestedAssetsById(attestationDetails?.attestedAssets);
 
   return (
     <div className="space-y-6 p-1 md:p-2 animate-fade-in min-h-screen">
@@ -494,7 +533,11 @@ export default function MyAttestationsPage() {
                         <TableBody>
                           {attestationDetails.assets?.map((asset) => {
                             const isCertified = certifiedAssetIds.has(asset.id);
-                            const selectedStatus = selectedStatuses[asset.id] || asset.status;
+                            const currentAttestation = currentAttestationsByAssetId[asset.id];
+                            const selectedStatus = selectedStatuses[asset.id] || getInitialStatusForAsset(asset, currentAttestation);
+                            const returnedDateDisplay = currentAttestation?.returned_date
+                              || asset.last_certification_result?.returned_date
+                              || asset.returned_date;
                             const showReturnedDate = selectedStatus === 'returned' && !isCertified;
                             return (
                               <TableRow key={asset.id} className={isCertified ? 'bg-success/10' : ''}>
@@ -511,9 +554,9 @@ export default function MyAttestationsPage() {
                                   {isCertified ? (
                                     <div className="space-y-1">
                                       <Badge variant="outline">{selectedStatus}</Badge>
-                                      {asset.returned_date && (
+                                      {returnedDateDisplay && (
                                         <div className="text-xs text-muted-foreground">
-                                          Returned: {new Date(asset.returned_date).toLocaleDateString()}
+                                          Returned: {new Date(returnedDateDisplay).toLocaleDateString()}
                                         </div>
                                       )}
                                     </div>
@@ -582,7 +625,11 @@ export default function MyAttestationsPage() {
                     <div className="md:hidden space-y-4">
                       {attestationDetails.assets?.map((asset, index) => {
                         const isCertified = certifiedAssetIds.has(asset.id);
-                        const selectedStatus = selectedStatuses[asset.id] || asset.status;
+                        const currentAttestation = currentAttestationsByAssetId[asset.id];
+                        const selectedStatus = selectedStatuses[asset.id] || getInitialStatusForAsset(asset, currentAttestation);
+                        const returnedDateDisplay = currentAttestation?.returned_date
+                          || asset.last_certification_result?.returned_date
+                          || asset.returned_date;
                         const showReturnedDate = selectedStatus === 'returned' && !isCertified;
                         return (
                           <div
@@ -632,9 +679,9 @@ export default function MyAttestationsPage() {
                                   {isCertified ? (
                                     <div className="mt-1 space-y-1">
                                       <Badge variant="outline">{selectedStatus}</Badge>
-                                      {asset.returned_date && (
+                                      {returnedDateDisplay && (
                                         <div className="text-xs text-muted-foreground">
-                                          Returned: {new Date(asset.returned_date).toLocaleDateString()}
+                                          Returned: {new Date(returnedDateDisplay).toLocaleDateString()}
                                         </div>
                                       )}
                                     </div>

--- a/frontend/src/pages/MyAttestationsPage.test.jsx
+++ b/frontend/src/pages/MyAttestationsPage.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import MyAttestationsPage from './MyAttestationsPage';
 
@@ -189,6 +190,107 @@ describe('MyAttestationsPage', () => {
         );
         expect(screen.getByText('TAG-123')).toBeInTheDocument();
         expect(screen.getByText('Dell XPS')).toBeInTheDocument();
+      });
+    });
+
+    it('prepopulates returned date from the last certification result when starting a new attestation', async () => {
+      const user = userEvent.setup();
+
+      global.fetch.mockImplementation((url) => {
+        if (url === '/api/attestation/my-attestations') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              attestations: [
+                {
+                  id: 77,
+                  status: 'pending',
+                  campaign: {
+                    name: 'Monthly Certification',
+                    description: 'March asset review',
+                    start_date: '2026-03-01',
+                    end_date: '2026-03-31'
+                  }
+                }
+              ]
+            })
+          });
+        }
+
+        if (url === '/api/asset-types') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ([{ id: 1, name: 'laptop', display_name: 'Laptop' }])
+          });
+        }
+
+        if (url === '/api/attestation/records/77') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              campaign: {
+                id: 900,
+                name: 'Monthly Certification'
+              },
+              assets: [
+                {
+                  id: 501,
+                  asset_type: 'Laptop',
+                  company_name: 'Acme Corp',
+                  make: 'Dell',
+                  model: 'Latitude',
+                  serial_number: 'SN-501',
+                  status: 'active',
+                  returned_date: null,
+                  last_certification_result: {
+                    attested_status: 'returned',
+                    returned_date: '2026-02-15'
+                  }
+                }
+              ],
+              attestedAssets: [],
+              newAssets: []
+            })
+          });
+        }
+
+        if (url === '/api/attestation/records/77/assets/501') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ success: true })
+          });
+        }
+
+        return Promise.resolve({ ok: true, json: async () => [] });
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Monthly Certification')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /start/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /certify asset/i }).length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getAllByRole('button', { name: /certify asset/i })[0]);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/attestation/records/77/assets/501',
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify({
+              attested_status: 'returned',
+              returned_date: '2026-02-15',
+              notes: ''
+            })
+          })
+        );
       });
     });
   });

--- a/frontend/src/pages/MyAttestationsPage.test.jsx
+++ b/frontend/src/pages/MyAttestationsPage.test.jsx
@@ -293,5 +293,81 @@ describe('MyAttestationsPage', () => {
         );
       });
     });
+
+    it('renders only the eligible assets returned by the attestation details endpoint', async () => {
+      const user = userEvent.setup();
+
+      global.fetch.mockImplementation((url) => {
+        if (url === '/api/attestation/my-attestations') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              attestations: [
+                {
+                  id: 88,
+                  status: 'pending',
+                  campaign: {
+                    name: 'Filtered Certification',
+                    description: 'Only actionable assets remain',
+                    start_date: '2026-04-01',
+                    end_date: '2026-04-30'
+                  }
+                }
+              ]
+            })
+          });
+        }
+
+        if (url === '/api/asset-types') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ([{ id: 1, name: 'laptop', display_name: 'Laptop' }])
+          });
+        }
+
+        if (url === '/api/attestation/records/88') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              campaign: {
+                id: 901,
+                name: 'Filtered Certification'
+              },
+              assets: [
+                {
+                  id: 701,
+                  asset_tag: 'ACTIVE-701',
+                  asset_type: 'Laptop',
+                  company_name: 'Acme Corp',
+                  make: 'Framework',
+                  model: '13',
+                  serial_number: 'SN-701',
+                  status: 'active'
+                }
+              ],
+              attestedAssets: [],
+              newAssets: []
+            })
+          });
+        }
+
+        return Promise.resolve({ ok: true, json: async () => [] });
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Filtered Certification')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /start/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('SN-701')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('SN-702')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- store each attestation asset's returned date so prior certification details are preserved
- expose the latest certification result when loading a new attestation record
- prepopulate the attestation UI with the previous certified status and returned date for repeat certifications
- add backend and frontend regression coverage for the history lookup and prefilled submission flow

## Testing
- `cd backend && npm test -- --runInBand attestation-history.test.js`
- `cd frontend && npm test -- MyAttestationsPage.test.jsx`