### PR TITLE
[codex] Remove duplicate deploy-time test run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,9 @@ jobs:
   verify:
     uses: ./.github/workflows/verify-files.yml
 
-  test:
-    uses: ./.github/workflows/ci-tests.yml
-
   build:
     name: Build & Push
-    needs: [verify, test]
+    needs: [verify]
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
## Summary
- stop rerunning the full CI test workflow during main-branch deployment
- keep the lightweight critical-file verification gate before build and deploy

## Why
- PR validation already runs the full frontend/backend/E2E suite
- running the same reusable CI workflow again inside deploy adds cost and delays releases without adding much signal

## Impact
- faster deployments after merge
- lower GitHub Actions usage
- no change to PR validation coverage

## Validation
- reviewed the workflow dependency chain in `.github/workflows/deploy.yml`
