### PR TITLE
[codex] Add asset owner repair workflow

### DIFF
--- a/backend/asset-owner-repair.test.js
+++ b/backend/asset-owner-repair.test.js
@@ -1,0 +1,160 @@
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+
+import { assetDb, auditDb, companyDb, userDb } from './database.js';
+import { repairAssetOwners, resolveOwnerRepairSnapshot } from './services/assetOwnerRepair.js';
+
+const createdAssetIds = [];
+const createdCompanyIds = [];
+const createdUserIds = [];
+
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+describe('Asset owner repair', () => {
+  beforeAll(async () => {
+    await assetDb.init();
+  });
+
+  afterEach(async () => {
+    while (createdAssetIds.length) {
+      await assetDb.delete(createdAssetIds.pop());
+    }
+
+    while (createdUserIds.length) {
+      await userDb.delete(createdUserIds.pop());
+    }
+
+    while (createdCompanyIds.length) {
+      await companyDb.delete(createdCompanyIds.pop());
+    }
+  });
+
+  it('reconstructs the owner from audit history and restores the asset in apply mode', async () => {
+    const suffix = uniqueSuffix();
+    const company = await companyDb.create({
+      name: `Repair Co ${suffix}`,
+      description: 'Asset owner repair test'
+    });
+    createdCompanyIds.push(company.id);
+
+    await userDb.create({
+      email: `repair-owner-${suffix}@test.com`,
+      password_hash: 'hash',
+      name: 'Repair Owner',
+      role: 'employee',
+      first_name: 'Riley',
+      last_name: 'Owner'
+    });
+    const user = await userDb.getByEmail(`repair-owner-${suffix}@test.com`);
+    createdUserIds.push(user.id);
+
+    const createdAsset = await assetDb.create({
+      employee_first_name: 'Riley',
+      employee_last_name: 'Owner',
+      employee_email: user.email,
+      company_name: `Repair Co ${suffix}`,
+      asset_type: 'laptop',
+      make: 'Dell',
+      model: 'Latitude',
+      serial_number: `REPAIR-${suffix}`,
+      asset_tag: `REPAIR-TAG-${suffix}`,
+      status: 'active',
+      notes: 'Original state'
+    });
+    createdAssetIds.push(createdAsset.id);
+
+    await auditDb.log(
+      'CREATE',
+      'asset',
+      createdAsset.id,
+      `REPAIR-${suffix} - Riley Owner`,
+      {
+        employee_first_name: 'Riley',
+        employee_last_name: 'Owner',
+        employee_email: user.email,
+        company_name: `Repair Co ${suffix}`,
+        asset_type: 'laptop',
+        serial_number: `REPAIR-${suffix}`
+      },
+      'admin@test.com'
+    );
+
+    await assetDb.update(createdAsset.id, {
+      employee_first_name: '',
+      employee_last_name: '',
+      employee_email: '',
+      company_name: `Repair Co ${suffix}`,
+      asset_type: 'laptop',
+      make: 'Dell',
+      model: 'Latitude',
+      serial_number: `REPAIR-${suffix}`,
+      asset_tag: `REPAIR-TAG-${suffix}`,
+      status: 'active',
+      notes: 'Corrupted state'
+    });
+
+    const damagedAsset = await assetDb.getById(createdAsset.id);
+    expect(damagedAsset.employee_email).toBe('');
+    expect(damagedAsset.owner_id).toBeNull();
+
+    const dryRunSummary = await repairAssetOwners({
+      assetId: createdAsset.id
+    });
+    expect(dryRunSummary.repaired).toBe(0);
+    expect(dryRunSummary.results).toHaveLength(1);
+    expect(dryRunSummary.results[0]).toEqual(expect.objectContaining({
+      status: 'dry-run',
+      to: expect.objectContaining({
+        employee_first_name: 'Riley',
+        employee_last_name: 'Owner',
+        employee_email: user.email
+      })
+    }));
+
+    const applySummary = await repairAssetOwners({
+      apply: true,
+      assetId: createdAsset.id
+    });
+
+    expect(applySummary.repaired).toBe(1);
+    const repairedAsset = await assetDb.getById(createdAsset.id);
+    expect(repairedAsset).toEqual(expect.objectContaining({
+      employee_first_name: 'Riley',
+      employee_last_name: 'Owner',
+      employee_email: user.email,
+      owner_id: user.id
+    }));
+
+    const auditLogs = await auditDb.getByEntity('asset', createdAsset.id);
+    expect(auditLogs.some((log) => log.action === 'REPAIR')).toBe(true);
+  });
+
+  it('uses the current email plus the user record when names are missing', async () => {
+    const logs = [];
+    const asset = {
+      employee_email: 'repair-name-fill@test.com',
+      employee_first_name: '',
+      employee_last_name: '',
+      owner_id: null
+    };
+    const fakeUserDb = {
+      async getByEmail(email) {
+        if (email.toLowerCase() === 'repair-name-fill@test.com') {
+          return {
+            id: 99,
+            first_name: 'Pat',
+            last_name: 'Example'
+          };
+        }
+        return null;
+      }
+    };
+
+    const resolved = await resolveOwnerRepairSnapshot(asset, logs, fakeUserDb);
+    expect(resolved).toEqual(expect.objectContaining({
+      email: 'repair-name-fill@test.com',
+      firstName: 'Pat',
+      lastName: 'Example',
+      matchedUserId: 99
+    }));
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
+    "repair:asset-owners": "node scripts/repair-asset-owners.js",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",

--- a/backend/scripts/repair-asset-owners.js
+++ b/backend/scripts/repair-asset-owners.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { assetDb } from '../database.js';
+import { formatRepairSummary, repairAssetOwners } from '../services/assetOwnerRepair.js';
+
+const args = process.argv.slice(2);
+const hasFlag = (flag) => args.includes(flag);
+const readOption = (name) => {
+  const exact = `${name}=`;
+  const found = args.find((arg) => arg.startsWith(exact));
+  return found ? found.slice(exact.length) : null;
+};
+
+const apply = hasFlag('--apply');
+const assetId = readOption('--asset-id');
+const limit = readOption('--limit');
+
+const parsedAssetId = assetId ? Number.parseInt(assetId, 10) : null;
+const parsedLimit = limit ? Number.parseInt(limit, 10) : null;
+
+if (assetId && !Number.isInteger(parsedAssetId)) {
+  console.error(`Invalid --asset-id value: ${assetId}`);
+  process.exit(1);
+}
+
+if (limit && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+  console.error(`Invalid --limit value: ${limit}`);
+  process.exit(1);
+}
+
+await assetDb.init();
+
+const summary = await repairAssetOwners({
+  apply,
+  assetId: parsedAssetId,
+  limit: parsedLimit
+});
+
+console.log(formatRepairSummary(summary));
+
+if (!apply) {
+  console.log('\nDry run only. Re-run with --apply to persist the repairs.');
+}

--- a/backend/services/assetOwnerRepair.js
+++ b/backend/services/assetOwnerRepair.js
@@ -1,0 +1,311 @@
+import { fileURLToPath } from 'url';
+import { resolve } from 'path';
+
+import { assetDb, auditDb, userDb } from '../database.js';
+import { safeJsonParseObject } from '../utils/json.js';
+import logger from '../utils/logger.js';
+
+const INVALID_OWNER_VALUES = new Set(['', 'n/a', 'na', 'null', 'undefined', 'unknown']);
+
+const normalizeOwnerValue = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return INVALID_OWNER_VALUES.has(normalized.toLowerCase()) ? null : normalized;
+};
+
+const parseEntityName = (entityName) => {
+  const normalized = normalizeOwnerValue(entityName);
+  if (!normalized) {
+    return { firstName: null, lastName: null };
+  }
+
+  const delimiterIndex = normalized.indexOf(' - ');
+  const namePart = delimiterIndex >= 0 ? normalized.slice(delimiterIndex + 3).trim() : normalized;
+  const cleanName = normalizeOwnerValue(namePart);
+
+  if (!cleanName) {
+    return { firstName: null, lastName: null };
+  }
+
+  const parts = cleanName.split(/\s+/).filter(Boolean);
+  if (parts.length < 2) {
+    return { firstName: null, lastName: null };
+  }
+
+  return {
+    firstName: normalizeOwnerValue(parts[0]),
+    lastName: normalizeOwnerValue(parts.slice(1).join(' '))
+  };
+};
+
+export const isAssetOwnerRepairCandidate = (asset) => {
+  if (!asset || asset.owner_id) {
+    return false;
+  }
+
+  return !normalizeOwnerValue(asset.employee_email)
+    || !normalizeOwnerValue(asset.employee_first_name)
+    || !normalizeOwnerValue(asset.employee_last_name);
+};
+
+export const extractOwnerSnapshotFromAuditLog = (log) => {
+  const details = safeJsonParseObject(log?.details, {});
+  const changes = details.changes && typeof details.changes === 'object' ? details.changes : {};
+  const parsedEntityName = parseEntityName(log?.entity_name);
+
+  return {
+    email: normalizeOwnerValue(changes.employee_email)
+      || normalizeOwnerValue(details.employee_email),
+    firstName: normalizeOwnerValue(changes.employee_first_name)
+      || normalizeOwnerValue(details.employee_first_name)
+      || parsedEntityName.firstName,
+    lastName: normalizeOwnerValue(changes.employee_last_name)
+      || normalizeOwnerValue(details.employee_last_name)
+      || parsedEntityName.lastName,
+    auditId: log?.id ?? null,
+    action: log?.action ?? null,
+    timestamp: log?.timestamp ?? null
+  };
+};
+
+const findNamesForEmailInLogs = (logs, email) => {
+  const normalizedEmail = normalizeOwnerValue(email)?.toLowerCase();
+  if (!normalizedEmail) {
+    return { firstName: null, lastName: null };
+  }
+
+  for (const log of logs) {
+    const snapshot = extractOwnerSnapshotFromAuditLog(log);
+    if (snapshot.email?.toLowerCase() !== normalizedEmail) {
+      continue;
+    }
+
+    if (snapshot.firstName && snapshot.lastName) {
+      return {
+        firstName: snapshot.firstName,
+        lastName: snapshot.lastName
+      };
+    }
+  }
+
+  return { firstName: null, lastName: null };
+};
+
+export const resolveOwnerRepairSnapshot = async (asset, logs, users = userDb) => {
+  const currentSnapshot = {
+    email: normalizeOwnerValue(asset.employee_email),
+    firstName: normalizeOwnerValue(asset.employee_first_name),
+    lastName: normalizeOwnerValue(asset.employee_last_name)
+  };
+
+  let candidateEmail = currentSnapshot.email;
+  let sourceAuditId = null;
+  let sourceAction = currentSnapshot.email ? 'current_asset' : null;
+
+  if (!candidateEmail) {
+    for (const log of logs) {
+      const snapshot = extractOwnerSnapshotFromAuditLog(log);
+      if (!snapshot.email) {
+        continue;
+      }
+
+      candidateEmail = snapshot.email;
+      sourceAuditId = snapshot.auditId;
+      sourceAction = snapshot.action;
+      currentSnapshot.firstName = currentSnapshot.firstName || snapshot.firstName;
+      currentSnapshot.lastName = currentSnapshot.lastName || snapshot.lastName;
+      break;
+    }
+  }
+
+  if (!candidateEmail) {
+    return null;
+  }
+
+  let firstName = currentSnapshot.firstName;
+  let lastName = currentSnapshot.lastName;
+
+  const matchedUser = await users.getByEmail(candidateEmail);
+  if (matchedUser) {
+    firstName = firstName || normalizeOwnerValue(matchedUser.first_name);
+    lastName = lastName || normalizeOwnerValue(matchedUser.last_name);
+  }
+
+  if (!firstName || !lastName) {
+    const historicalNames = findNamesForEmailInLogs(logs, candidateEmail);
+    firstName = firstName || historicalNames.firstName;
+    lastName = lastName || historicalNames.lastName;
+  }
+
+  if (!firstName || !lastName) {
+    return null;
+  }
+
+  return {
+    email: candidateEmail,
+    firstName,
+    lastName,
+    sourceAuditId,
+    sourceAction,
+    matchedUserId: matchedUser?.id ?? null
+  };
+};
+
+export const repairAssetOwners = async (options = {}, deps = {}) => {
+  const {
+    apply = false,
+    assetId = null,
+    limit = null
+  } = options;
+
+  const assets = deps.assetDb || assetDb;
+  const audits = deps.auditDb || auditDb;
+  const users = deps.userDb || userDb;
+
+  const allAssets = assetId
+    ? [await assets.getById(assetId)].filter(Boolean)
+    : await assets.getAll();
+
+  const candidates = allAssets.filter(isAssetOwnerRepairCandidate);
+  const limitedCandidates = Number.isInteger(limit) && limit > 0
+    ? candidates.slice(0, limit)
+    : candidates;
+
+  const summary = {
+    apply,
+    scanned: allAssets.length,
+    candidates: limitedCandidates.length,
+    repaired: 0,
+    skipped: 0,
+    skippedNoRecoveryData: 0,
+    results: []
+  };
+
+  for (const candidate of limitedCandidates) {
+    const logs = await audits.getByEntity('asset', candidate.id);
+    const resolved = await resolveOwnerRepairSnapshot(candidate, logs, users);
+
+    if (!resolved) {
+      summary.skipped += 1;
+      summary.skippedNoRecoveryData += 1;
+      summary.results.push({
+        assetId: candidate.id,
+        serialNumber: candidate.serial_number,
+        status: 'skipped',
+        reason: 'No trustworthy owner identity found in current data or audit history'
+      });
+      continue;
+    }
+
+    const repairRecord = {
+      assetId: candidate.id,
+      serialNumber: candidate.serial_number,
+      status: apply ? 'repaired' : 'dry-run',
+      from: {
+        employee_first_name: candidate.employee_first_name || '',
+        employee_last_name: candidate.employee_last_name || '',
+        employee_email: candidate.employee_email || '',
+        owner_id: candidate.owner_id || null
+      },
+      to: {
+        employee_first_name: resolved.firstName,
+        employee_last_name: resolved.lastName,
+        employee_email: resolved.email,
+        owner_id: resolved.matchedUserId
+      },
+      sourceAuditId: resolved.sourceAuditId,
+      sourceAction: resolved.sourceAction
+    };
+
+    if (apply) {
+      await assets.update(candidate.id, {
+        employee_first_name: resolved.firstName,
+        employee_last_name: resolved.lastName,
+        employee_email: resolved.email
+      });
+
+      const updatedAsset = await assets.getById(candidate.id);
+      repairRecord.to.owner_id = updatedAsset?.owner_id ?? resolved.matchedUserId;
+
+      await audits.log(
+        'REPAIR',
+        'asset',
+        candidate.id,
+        `${candidate.serial_number} - ${resolved.firstName} ${resolved.lastName}`,
+        {
+          repair_type: 'owner_identity_backfill',
+          previous_owner: repairRecord.from,
+          restored_owner: repairRecord.to,
+          source_audit_id: resolved.sourceAuditId,
+          source_action: resolved.sourceAction
+        },
+        'system'
+      );
+
+      summary.repaired += 1;
+    }
+
+    summary.results.push(repairRecord);
+  }
+
+  logger.info({
+    scanned: summary.scanned,
+    candidates: summary.candidates,
+    repaired: summary.repaired,
+    skipped: summary.skipped,
+    apply
+  }, 'Asset owner repair run completed');
+
+  return summary;
+};
+
+export const formatRepairSummary = (summary) => {
+  const formatName = (firstName, lastName) => [firstName, lastName].filter(Boolean).join(' ').trim() || 'blank';
+  const lines = [
+    `Mode: ${summary.apply ? 'apply' : 'dry-run'}`,
+    `Scanned assets: ${summary.scanned}`,
+    `Repair candidates: ${summary.candidates}`,
+    `Repaired: ${summary.repaired}`,
+    `Skipped: ${summary.skipped}`
+  ];
+
+  if (summary.results.length > 0) {
+    lines.push('');
+    lines.push('Details:');
+    for (const result of summary.results) {
+      if (result.status === 'skipped') {
+        lines.push(`- Asset #${result.assetId} (${result.serialNumber}): skipped, ${result.reason}`);
+        continue;
+      }
+
+      lines.push(
+        `- Asset #${result.assetId} (${result.serialNumber}): ${result.status}, `
+        + `${formatName(result.from.employee_first_name, result.from.employee_last_name)} -> `
+        + `${formatName(result.to.employee_first_name, result.to.employee_last_name)} `
+        + `(${result.from.employee_email || 'blank'} -> ${result.to.employee_email})`
+      );
+    }
+  }
+
+  return lines.join('\n');
+};
+
+const isDirectRun = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  logger.warn('Run backend/scripts/repair-asset-owners.js instead of invoking assetOwnerRepair.js directly');
+}

--- a/docs/_discovery.md
+++ b/docs/_discovery.md
@@ -1,0 +1,27 @@
+# Discovery Notes
+
+## Asset Owner Repair SOP
+
+- Repository: ACS (Asset Compliance System)
+- Backend runtime: Node.js service in `backend/`
+- Database configuration comes from environment variables:
+  - `DB_CLIENT=sqlite` or `postgres`
+  - `POSTGRES_URL` for PostgreSQL
+  - `DATA_DIR` for SQLite file storage
+- Production backend images copy the full backend source into `/app` and run Node from there
+- Repair command added for this workflow:
+  - `npm run repair:asset-owners`
+- Repair script path:
+  - `backend/scripts/repair-asset-owners.js`
+- Repair logic path:
+  - `backend/services/assetOwnerRepair.js`
+- Recovery source used by the repair:
+  - Current asset owner fields, when partially present
+  - `users` table, when `employee_email` is still known
+  - `audit_logs` entries for the same asset, especially `CREATE` logs
+- Safety model:
+  - Only repairs assets that are clearly broken now
+  - Only applies a repair when it can reconstruct a trustworthy owner identity
+  - Writes a `REPAIR` audit log for every applied fix
+- Limitation:
+  - Some assets may remain skipped if neither the current row nor the audit trail contains enough owner data to restore them automatically

--- a/docs/asset-owner-repair-sop.md
+++ b/docs/asset-owner-repair-sop.md
@@ -1,0 +1,307 @@
+# ACS Production SOP: Repair Assets Showing `N/A` as Owner
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [When to Use This SOP](#when-to-use-this-sop)
+3. [What the Repair Does](#what-the-repair-does)
+4. [Prerequisites](#prerequisites)
+5. [Safety Rules](#safety-rules)
+6. [Step 1: Confirm the Fix Is Deployed](#step-1-confirm-the-fix-is-deployed)
+7. [Step 2: Take a Production Database Backup](#step-2-take-a-production-database-backup)
+8. [Step 3: Open a Shell in the Production Backend Runtime](#step-3-open-a-shell-in-the-production-backend-runtime)
+9. [Step 4: Run a Dry Run First](#step-4-run-a-dry-run-first)
+10. [Step 5: Review the Dry Run Output](#step-5-review-the-dry-run-output)
+11. [Step 6: Apply the Repair](#step-6-apply-the-repair)
+12. [Step 7: Verify the Results](#step-7-verify-the-results)
+13. [Step 8: Handle Any Skipped Assets](#step-8-handle-any-skipped-assets)
+14. [Rollback Plan](#rollback-plan)
+15. [Command Reference](#command-reference)
+
+## Purpose
+
+This SOP explains how to repair production assets whose owner shows as `N/A` because the asset’s stored owner fields were previously blanked during self-editing.
+
+## When to Use This SOP
+
+Use this SOP when:
+
+- An asset shows `N/A` for owner name in the UI
+- The affected asset no longer has a valid `employee_first_name`, `employee_last_name`, `employee_email`, or `owner_id`
+- The backend version containing the repair command has already been deployed
+
+Do not use this SOP for unrelated data problems.
+
+## What the Repair Does
+
+The repair command:
+
+- Scans for assets with broken owner data
+- Reconstructs the owner using the asset’s own audit history and, when possible, the `users` table
+- Updates the asset only if it can determine a trustworthy owner identity
+- Writes a `REPAIR` audit log entry for each asset it changes
+
+The repair command does not guess. If it cannot recover a trustworthy owner, it skips that asset.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- Production access to the backend runtime or container
+- Permission to take a production database backup
+- A maintenance window or at least a low-traffic window
+- The production build that includes:
+  - `backend/scripts/repair-asset-owners.js`
+  - `backend/services/assetOwnerRepair.js`
+  - `backend/package.json` script `repair:asset-owners`
+
+## Safety Rules
+
+1. Always run a dry run before `--apply`.
+2. Always take a production database backup first.
+3. Do not point this command at the wrong environment.
+4. Prefer running during a low-traffic period so asset edits are not happening at the same time.
+5. If the dry run output looks wrong, stop and investigate before applying anything.
+
+> **Warning:** Do not run `--apply` until you have confirmed the output is from the production database you intend to repair.
+
+## Step 1: Confirm the Fix Is Deployed
+
+From the production backend checkout or runtime image, verify the script exists:
+
+```bash
+cd /app/backend
+ls scripts/repair-asset-owners.js
+```
+
+If your production checkout is not under `/app/backend`, adjust the path accordingly. The important part is that the backend code currently running in production includes the repair script.
+
+You can also verify the npm script exists:
+
+```bash
+cd /app/backend
+npm run | grep repair:asset-owners
+```
+
+## Step 2: Take a Production Database Backup
+
+Take a backup using your normal production backup process before running anything.
+
+Examples:
+
+- PostgreSQL: create a fresh dump or snapshot of the production database
+- SQLite: copy the production database file from the configured `DATA_DIR`
+
+Record the following in your change log or ticket:
+
+- Backup timestamp
+- Database name or file path
+- Environment name
+- Person performing the repair
+
+> **Warning:** Do not skip the backup. This SOP modifies production asset records.
+
+## Step 3: Open a Shell in the Production Backend Runtime
+
+Open a shell in the production backend environment where the backend already has the correct production environment variables.
+
+Examples:
+
+- Docker:
+
+```bash
+docker exec -it <backend-container-name> sh
+```
+
+- Kubernetes:
+
+```bash
+kubectl exec -it <backend-pod-name> -- sh
+```
+
+- Managed container platform:
+
+Use your platform’s exec or console feature to open a shell in the backend container.
+
+Once inside:
+
+```bash
+cd /app/backend
+pwd
+```
+
+The working directory should contain `package.json`, `server.js`, and `scripts/repair-asset-owners.js`.
+
+## Step 4: Run a Dry Run First
+
+Start with a small sample:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners -- --limit=20
+```
+
+If the sample looks correct, run the full dry run:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners
+```
+
+If you want to inspect one specific asset first:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners -- --asset-id=123
+```
+
+## Step 5: Review the Dry Run Output
+
+The dry run prints:
+
+- Total assets scanned
+- Repair candidates found
+- How many would be repaired
+- How many would be skipped
+- A detail line for each candidate
+
+Interpret the results like this:
+
+- `dry-run`: the asset is recoverable and would be repaired if you rerun with `--apply`
+- `skipped`: the command could not find enough trustworthy data to restore the owner automatically
+
+You are looking for:
+
+- Correct owner names and emails in the `to:` side of the output
+- No suspicious cross-user matches
+- A reasonable number of skipped assets
+
+If anything looks wrong, stop here.
+
+## Step 6: Apply the Repair
+
+Once the dry run output looks correct, run the apply command:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners -- --apply
+```
+
+If you want to repair one asset first as a final production check:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners -- --asset-id=123 --apply
+```
+
+What happens during apply:
+
+- The asset owner fields are restored
+- `owner_id` is repopulated when the owner email matches a registered user
+- A `REPAIR` audit log is created for that asset
+
+## Step 7: Verify the Results
+
+After the repair completes, verify in three ways.
+
+### 1. Re-run a Dry Run
+
+```bash
+cd /app/backend
+npm run repair:asset-owners
+```
+
+Expected result:
+
+- Previously repaired assets should no longer appear as candidates
+
+### 2. Check the UI
+
+In the production ACS UI:
+
+1. Open the Assets page as an admin.
+2. Search for several assets that were repaired.
+3. Confirm the owner name no longer shows `N/A`.
+4. Open a repaired asset and confirm the employee name and email are correct.
+
+### 3. Check the Audit Trail
+
+For any repaired asset, confirm there is a new `REPAIR` audit entry.
+
+This proves the change was applied intentionally and leaves an audit trail for SOC2 evidence.
+
+## Step 8: Handle Any Skipped Assets
+
+Some assets may still be skipped. This means the script could not reconstruct the owner safely from current asset data plus audit history.
+
+For each skipped asset:
+
+1. Note the asset ID and serial number from the dry run output.
+2. Review the asset’s history in the UI or database audit logs.
+3. Identify the correct owner manually.
+4. Update the asset as an admin through the application.
+5. Confirm the owner is no longer `N/A`.
+
+If needed, you can run the script again for one asset after manual investigation:
+
+```bash
+cd /app/backend
+npm run repair:asset-owners -- --asset-id=123 --apply
+```
+
+If the asset still skips after investigation, complete that one manually.
+
+> **Note:** A skipped asset is not a script failure. It is the intended safety behavior when there is not enough trustworthy recovery data.
+
+## Rollback Plan
+
+If the apply step produces unexpected results:
+
+1. Stop further repair runs immediately.
+2. Record the time of the repair run.
+3. Identify the affected assets from the command output and audit logs.
+4. Restore from the database backup if the issue is broad.
+5. If only a small number of records are affected, correct those assets manually using the audit trail.
+
+Because the repair writes `REPAIR` audit log entries, you can identify exactly which assets were changed by the command.
+
+## Command Reference
+
+Run a small dry run:
+
+```bash
+npm run repair:asset-owners -- --limit=20
+```
+
+Run a full dry run:
+
+```bash
+npm run repair:asset-owners
+```
+
+Repair one asset only:
+
+```bash
+npm run repair:asset-owners -- --asset-id=123 --apply
+```
+
+Apply the repair to all recoverable assets:
+
+```bash
+npm run repair:asset-owners -- --apply
+```
+
+## Recommended Production Sequence
+
+Use this exact sequence in production:
+
+1. Confirm the repair code is deployed.
+2. Take a production database backup.
+3. Open a shell in the production backend container.
+4. Run `npm run repair:asset-owners -- --limit=20`.
+5. Review the sample output carefully.
+6. Run `npm run repair:asset-owners`.
+7. Review the full dry run output.
+8. Run `npm run repair:asset-owners -- --apply`.
+9. Re-run `npm run repair:asset-owners` to confirm candidates are gone.
+10. Verify repaired assets in the ACS UI and audit logs.


### PR DESCRIPTION
## What changed
- added a backend repair service to recover corrupted asset owner fields from trusted audit history and current user data
- added a CLI command to run the repair in dry-run or apply mode
- added an SOP in `docs/asset-owner-repair-sop.md` describing the production workflow for backup, dry run, apply, verification, and rollback
- added focused backend tests for the repair path and the self-edit regression case

## Why
A previous self-edit bug could blank asset owner fields for employee-owned assets. The code fix prevents new corruption, but already-corrupted assets may still need repair. This PR adds a safe recovery workflow for those records.

## Impact
- admins can preview recoverable assets before changing production data
- only assets with trustworthy recovery data are updated
- each applied repair writes a `REPAIR` audit log entry for traceability
- unrecoverable assets are explicitly skipped for manual follow-up instead of being guessed at

## Root cause
The old non-admin asset update path stripped `employee_*` fields and then passed the reduced payload into `assetDb.update()`, which wrote blank owner data back onto the asset row.

## Validation
- `cd backend && npm test -- asset-owner-repair.test.js asset-self-edit-regression.test.js`
- `cd backend && npm run repair:asset-owners`
- full `cd backend && npm test` is still blocked in this environment by existing sandbox `EPERM` failures in suites that try to bind `0.0.0.0`
